### PR TITLE
fix: migration script and adding parsing passkeys

### DIFF
--- a/boolparser/token.go
+++ b/boolparser/token.go
@@ -20,4 +20,5 @@ const (
 	WHITESPACE
 	ERROR
 	EOF
+	PASSKEY
 )

--- a/x/policy/migrations/v2/migrate.go
+++ b/x/policy/migrations/v2/migrate.go
@@ -1,7 +1,7 @@
 package v3
 
 import (
-	"strconv"
+	"strings"
 
 	"cosmossdk.io/collections"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -27,18 +27,18 @@ func UpdatePolicies(ctx sdk.Context, policyCol collections.Map[uint64, types.Pol
 		}
 		bpPolicy := rawPolicy.(*types.BoolparserPolicy)
 
-		approverNumber, err := bpPolicy.GetApproverNumber()
-		if err != nil {
-			return err
-		}
 		approvers := bpPolicy.GetParticipantAddresses()
-		var newDefinition string
-		for i, approver := range approvers {
-			if i == len(approvers)-1 {
-				newDefinition += approver + " > " + strconv.Itoa(approverNumber)
-			} else {
-				newDefinition += approver + " + "
+
+		abbrToAddr := make(map[string]string)
+		for _, participant := range bpPolicy.Participants {
+			if participant.Abbreviation != "" {
+				abbrToAddr[participant.Abbreviation] = participant.Address
 			}
+		}
+
+		newDefinition := bpPolicy.Definition
+		for abbr, addr := range abbrToAddr {
+			newDefinition = strings.ReplaceAll(newDefinition, abbr, addr)
 		}
 		bpPolicy.Definition = newDefinition
 

--- a/x/policy/types/policy.go
+++ b/x/policy/types/policy.go
@@ -110,7 +110,12 @@ func (p *BoolparserPolicy) GetParticipantAddresses() []string {
 func (p *BoolparserPolicy) GetApproverNumber() (int, error) {
 
 	// Split the string into parts
-	parts := strings.Fields(p.Definition)
+	parser := boolparser.NewParser(strings.NewReader(p.Definition))
+	stack, err := parser.Parse()
+	if err != nil {
+		return 0, fmt.Errorf("error parsing definition: %w", err)
+	}
+	parts := stack.Values
 
 	// Check if there are any parts
 	if len(parts) == 0 {
@@ -121,9 +126,9 @@ func (p *BoolparserPolicy) GetApproverNumber() (int, error) {
 	lastValue := parts[len(parts)-1]
 
 	// Convert the last part to an integer
-	approverNumber, err := strconv.Atoi(lastValue)
+	approverNumber, err := strconv.Atoi(lastValue.Value)
 	if err != nil {
-		return 0, fmt.Errorf("error converting '%s' to int: %v", lastValue, err)
+		return 0, fmt.Errorf("error converting '%s' to int: %v", lastValue.Value, err)
 	}
 
 	return approverNumber, nil

--- a/x/policy/types/policy_test.go
+++ b/x/policy/types/policy_test.go
@@ -28,6 +28,31 @@ func TestBoolparserPolicy_Validate(t *testing.T) {
 			},
 		},
 		{
+			name: "pass: one participant",
+			bp: BoolparserPolicy{
+				Definition: "zen13y3tm68gmu9kntcxwvmue82p6akacnpt2v7nty > 0",
+				Participants: []*PolicyParticipant{
+					{
+						Address: "zen13y3tm68gmu9kntcxwvmue82p6akacnpt2v7nty",
+					},
+				},
+			},
+		},
+		{
+			name: "pass: no spaces",
+			bp: BoolparserPolicy{
+				Definition: "zen13y3tm68gmu9kntcxwvmue82p6akacnpt2v7nty+zen126hek6zagmp3jqf97x7pq7c0j9jqs0ndxeaqhq>1",
+				Participants: []*PolicyParticipant{
+					{
+						Address: "zen13y3tm68gmu9kntcxwvmue82p6akacnpt2v7nty",
+					},
+					{
+						Address: "zen126hek6zagmp3jqf97x7pq7c0j9jqs0ndxeaqhq",
+					},
+				},
+			},
+		},
+		{
 			name: "fail: missing participant",
 			bp: BoolparserPolicy{
 				Definition: "zen13y3tm68gmu9kntcxwvmue82p6akacnpt2v7nty + u2 > 1",


### PR DESCRIPTION
This PR fixes the migration script for policy module `v2`. The definition is now properly parsed and `abbreviations` are getting replaced with a map by the respective `addresses`.  

To support parsing passkeys, another method in the boolparser scanner was added that identifies a passkey. This was required as the passkeys are being part of the policy definition and need to be parsed as well.