### PR TITLE
fix: remove treasury keeper

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -469,7 +469,6 @@ func NewZenrockApp(
 		app.BankKeeper,
 		authtypes.FeeCollectorName,
 		authAddr,
-		app.TreasuryKeeper,
 	)
 
 	app.DistrKeeper = distrkeeper.NewKeeper(

--- a/x/mint/keeper/genesis_test.go
+++ b/x/mint/keeper/genesis_test.go
@@ -52,12 +52,11 @@ func (s *GenesisTestSuite) SetupTest() {
 	stakingKeeper := minttestutil.NewMockStakingKeeper(ctrl)
 	accountKeeper := minttestutil.NewMockAccountKeeper(ctrl)
 	bankKeeper := minttestutil.NewMockBankKeeper(ctrl)
-	treasuryKeeper := minttestutil.NewMockTreasuryKeeper(ctrl)
 	s.accountKeeper = accountKeeper
 	accountKeeper.EXPECT().GetModuleAddress(minterAcc.Name).Return(minterAcc.GetAddress())
 	accountKeeper.EXPECT().GetModuleAccount(s.sdkCtx, minterAcc.Name).Return(minterAcc)
 
-	s.keeper = keeper.NewKeeper(s.cdc, runtime.NewKVStoreService(key), stakingKeeper, accountKeeper, bankKeeper, authtypes.FeeCollectorName, "", treasuryKeeper)
+	s.keeper = keeper.NewKeeper(s.cdc, runtime.NewKVStoreService(key), stakingKeeper, accountKeeper, bankKeeper, authtypes.FeeCollectorName, "")
 }
 
 func (s *GenesisTestSuite) TestImportExportGenesis() {

--- a/x/mint/keeper/grpc_query_test.go
+++ b/x/mint/keeper/grpc_query_test.go
@@ -42,7 +42,6 @@ func (suite *MintTestSuite) SetupTest() {
 	accountKeeper := minttestutil.NewMockAccountKeeper(ctrl)
 	bankKeeper := minttestutil.NewMockBankKeeper(ctrl)
 	stakingKeeper := minttestutil.NewMockStakingKeeper(ctrl)
-	treasuryKeeper := minttestutil.NewMockTreasuryKeeper(ctrl)
 	accountKeeper.EXPECT().GetModuleAddress("mint").Return(sdk.AccAddress{})
 
 	suite.mintKeeper = keeper.NewKeeper(
@@ -53,7 +52,6 @@ func (suite *MintTestSuite) SetupTest() {
 		bankKeeper,
 		authtypes.FeeCollectorName,
 		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
-		treasuryKeeper,
 	)
 
 	err := suite.mintKeeper.Params.Set(suite.ctx, types.DefaultParams())

--- a/x/mint/keeper/keeper.go
+++ b/x/mint/keeper/keeper.go
@@ -18,12 +18,11 @@ import (
 
 // Keeper of the mint store
 type Keeper struct {
-	cdc            codec.BinaryCodec
-	storeService   storetypes.KVStoreService
-	stakingKeeper  types.StakingKeeper
-	bankKeeper     types.BankKeeper
-	treasuryKeeper types.TreasuryKeeper
-	accountKeeper  types.AccountKeeper
+	cdc           codec.BinaryCodec
+	storeService  storetypes.KVStoreService
+	stakingKeeper types.StakingKeeper
+	bankKeeper    types.BankKeeper
+	accountKeeper types.AccountKeeper
 
 	feeCollectorName string
 
@@ -45,7 +44,6 @@ func NewKeeper(
 	bk types.BankKeeper,
 	feeCollectorName string,
 	authority string,
-	tk types.TreasuryKeeper,
 ) Keeper {
 	// ensure mint module account is set
 	if addr := ak.GetModuleAddress(types.ModuleName); addr == nil {
@@ -63,7 +61,6 @@ func NewKeeper(
 		authority:        authority,
 		Params:           collections.NewItem(sb, types.ParamsKey, "params", codec.CollValue[types.Params](cdc)),
 		Minter:           collections.NewItem(sb, types.MinterKey, "minter", codec.CollValue[types.Minter](cdc)),
-		treasuryKeeper:   tk,
 	}
 
 	schema, err := sb.Build()

--- a/x/mint/keeper/keeper_test.go
+++ b/x/mint/keeper/keeper_test.go
@@ -26,13 +26,12 @@ import (
 type IntegrationTestSuite struct {
 	suite.Suite
 
-	mintKeeper     keeper.Keeper
-	ctx            sdk.Context
-	msgServer      types.MsgServer
-	stakingKeeper  *minttestutil.MockStakingKeeper
-	bankKeeper     *minttestutil.MockBankKeeper
-	treasuryKeeper *minttestutil.MockTreasuryKeeper
-	accountKeeper  *minttestutil.MockAccountKeeper
+	mintKeeper    keeper.Keeper
+	ctx           sdk.Context
+	msgServer     types.MsgServer
+	stakingKeeper *minttestutil.MockStakingKeeper
+	bankKeeper    *minttestutil.MockBankKeeper
+	accountKeeper *minttestutil.MockAccountKeeper
 }
 
 func TestKeeperTestSuite(t *testing.T) {
@@ -51,15 +50,12 @@ func (s *IntegrationTestSuite) SetupTest() {
 	accountKeeper := minttestutil.NewMockAccountKeeper(ctrl)
 	bankKeeper := minttestutil.NewMockBankKeeper(ctrl)
 	stakingKeeper := minttestutil.NewMockStakingKeeper(ctrl)
-	treasuryKeeper := minttestutil.NewMockTreasuryKeeper(ctrl)
 	accountKeeper.EXPECT().GetModuleAddress(types.ModuleName).Return(sdk.AccAddress{})
 
 	// Assign the mock keepers to the suite fields
 	s.accountKeeper = accountKeeper
 	s.bankKeeper = bankKeeper
 	s.stakingKeeper = stakingKeeper
-	s.treasuryKeeper = treasuryKeeper
-
 	s.mintKeeper = keeper.NewKeeper(
 		encCfg.Codec,
 		storeService,
@@ -68,7 +64,6 @@ func (s *IntegrationTestSuite) SetupTest() {
 		bankKeeper,
 		authtypes.FeeCollectorName,
 		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
-		treasuryKeeper,
 	)
 
 	s.Require().Equal(testCtx.Ctx.Logger().With("module", "x/"+types.ModuleName),

--- a/x/mint/module.go
+++ b/x/mint/module.go
@@ -210,10 +210,9 @@ type ModuleInputs struct {
 	// LegacySubspace is used solely for migration of x/params managed parameters
 	LegacySubspace exported.Subspace `optional:"true"`
 
-	AccountKeeper  types.AccountKeeper
-	BankKeeper     types.BankKeeper
-	StakingKeeper  types.StakingKeeper
-	TreasuryKeeper types.TreasuryKeeper
+	AccountKeeper types.AccountKeeper
+	BankKeeper    types.BankKeeper
+	StakingKeeper types.StakingKeeper
 }
 
 type ModuleOutputs struct {
@@ -243,7 +242,6 @@ func ProvideModule(in ModuleInputs) ModuleOutputs {
 		in.BankKeeper,
 		feeCollectorName,
 		authority.String(),
-		in.TreasuryKeeper,
 	)
 
 	// when no inflation calculation function is provided it will use the default types.DefaultInflationCalculationFn

--- a/x/mint/testutil/expected_keepers_mocks.go
+++ b/x/mint/testutil/expected_keepers_mocks.go
@@ -24,28 +24,10 @@ type MockStakingKeeperMockRecorder struct {
 	mock *MockStakingKeeper
 }
 
-// MockTreasuryKeeper is a mock of TreasuryKeeper interface.
-type MockTreasuryKeeper struct {
-	ctrl     *gomock.Controller
-	recorder *MockTreasuryKeeperMockRecorder
-}
-
-// MockTreasuryKeeperMockRecorder is the mock recorder for MockTreasuryKeeper.
-type MockTreasuryKeeperMockRecorder struct {
-	mock *MockTreasuryKeeper
-}
-
 // NewMockStakingKeeper creates a new mock instance.
 func NewMockStakingKeeper(ctrl *gomock.Controller) *MockStakingKeeper {
 	mock := &MockStakingKeeper{ctrl: ctrl}
 	mock.recorder = &MockStakingKeeperMockRecorder{mock}
-	return mock
-}
-
-// NewMockTreasuryKeeper creates a new mock instance.
-func NewMockTreasuryKeeper(ctrl *gomock.Controller) *MockTreasuryKeeper {
-	mock := &MockTreasuryKeeper{ctrl: ctrl}
-	mock.recorder = &MockTreasuryKeeperMockRecorder{mock}
 	return mock
 }
 
@@ -185,6 +167,34 @@ func (m *MockBankKeeper) EXPECT() *MockBankKeeperMockRecorder {
 	return m.recorder
 }
 
+// BurnCoins mocks base method.
+func (m *MockBankKeeper) BurnCoins(ctx context.Context, name string, amt types.Coins) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BurnCoins", ctx, name, amt)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BurnCoins indicates an expected call of BurnCoins.
+func (mr *MockBankKeeperMockRecorder) BurnCoins(ctx, name, amt interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BurnCoins", reflect.TypeOf((*MockBankKeeper)(nil).BurnCoins), ctx, name, amt)
+}
+
+// GetBalance mocks base method.
+func (m *MockBankKeeper) GetBalance(ctx context.Context, addr types.AccAddress, denom string) types.Coin {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBalance", ctx, addr, denom)
+	ret0, _ := ret[0].(types.Coin)
+	return ret0
+}
+
+// GetBalance indicates an expected call of GetBalance.
+func (mr *MockBankKeeperMockRecorder) GetBalance(ctx, addr, denom interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBalance", reflect.TypeOf((*MockBankKeeper)(nil).GetBalance), ctx, addr, denom)
+}
+
 // MintCoins mocks base method.
 func (m *MockBankKeeper) MintCoins(ctx context.Context, name string, amt types.Coins) error {
 	m.ctrl.T.Helper()
@@ -197,6 +207,20 @@ func (m *MockBankKeeper) MintCoins(ctx context.Context, name string, amt types.C
 func (mr *MockBankKeeperMockRecorder) MintCoins(ctx, name, amt interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MintCoins", reflect.TypeOf((*MockBankKeeper)(nil).MintCoins), ctx, name, amt)
+}
+
+// SendCoinsFromAccountToModule mocks base method.
+func (m *MockBankKeeper) SendCoinsFromAccountToModule(ctx context.Context, senderAddr types.AccAddress, recipientModule string, amt types.Coins) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SendCoinsFromAccountToModule", ctx, senderAddr, recipientModule, amt)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SendCoinsFromAccountToModule indicates an expected call of SendCoinsFromAccountToModule.
+func (mr *MockBankKeeperMockRecorder) SendCoinsFromAccountToModule(ctx, senderAddr, recipientModule, amt interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendCoinsFromAccountToModule", reflect.TypeOf((*MockBankKeeper)(nil).SendCoinsFromAccountToModule), ctx, senderAddr, recipientModule, amt)
 }
 
 // SendCoinsFromModuleToAccount mocks base method.
@@ -225,44 +249,4 @@ func (m *MockBankKeeper) SendCoinsFromModuleToModule(ctx context.Context, sender
 func (mr *MockBankKeeperMockRecorder) SendCoinsFromModuleToModule(ctx, senderModule, recipientModule, amt interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendCoinsFromModuleToModule", reflect.TypeOf((*MockBankKeeper)(nil).SendCoinsFromModuleToModule), ctx, senderModule, recipientModule, amt)
-}
-
-// SendCoinsFromAccountToModule mocks base method.
-func (m *MockBankKeeper) SendCoinsFromAccountToModule(ctx context.Context, senderAddr types.AccAddress, recipientModule string, amt types.Coins) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SendCoinsFromAccountToModule", ctx, senderAddr, recipientModule, amt)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SendCoinsFromAccountToModule indicates an expected call of SendCoinsFromAccountToModule.
-func (mr *MockBankKeeperMockRecorder) SendCoinsFromAccountToModule(ctx, senderAddr, recipientModule, amt interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendCoinsFromAccountToModule", reflect.TypeOf((*MockBankKeeper)(nil).SendCoinsFromAccountToModule), ctx, senderAddr, recipientModule, amt)
-}
-
-// BurnCoins mocks base method.
-func (m *MockBankKeeper) BurnCoins(ctx context.Context, moduleName string, amt types.Coins) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BurnCoins", ctx, moduleName, amt)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// BurnCoins indicates an expected call of BurnCoins.
-func (mr *MockBankKeeperMockRecorder) BurnCoins(ctx, moduleName, amt interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BurnCoins", reflect.TypeOf((*MockBankKeeper)(nil).BurnCoins), ctx, moduleName, amt)
-}
-
-func (m *MockBankKeeper) GetBalance(ctx context.Context, addr types.AccAddress, denom string) types.Coin {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBalance", ctx, addr, denom)
-	ret0, _ := ret[0].(types.Coin)
-	return ret0
-}
-
-func (mr *MockBankKeeperMockRecorder) GetBalance(ctx, addr, denom interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBalance", reflect.TypeOf((*MockBankKeeper)(nil).GetBalance), ctx, addr, denom)
 }

--- a/x/mint/types/expected_keepers.go
+++ b/x/mint/types/expected_keepers.go
@@ -34,8 +34,3 @@ type BankKeeper interface {
 	GetBalance(ctx context.Context, addr sdk.AccAddress, denom string) sdk.Coin
 	BurnCoins(ctx context.Context, name string, amt sdk.Coins) error
 }
-
-// TreasuryKeeper defines the contract needed to be fulfilled for treasury
-// dependencies.
-type TreasuryKeeper interface {
-}


### PR DESCRIPTION
This PR removes the `treasurykeeper` from the `mintkeeper` and does a few cleanups