### PR TITLE
fix: missing zenbtc metadata

### DIFF
--- a/x/treasury/keeper/query_key_by_id.go
+++ b/x/treasury/keeper/query_key_by_id.go
@@ -20,13 +20,14 @@ func (k Keeper) KeyByID(goCtx context.Context, req *types.QueryKeyByIDRequest) (
 
 	return &types.QueryKeyByIDResponse{
 		Key: &types.KeyResponse{
-			Id:            key.Id,
-			WorkspaceAddr: key.WorkspaceAddr,
-			KeyringAddr:   key.KeyringAddr,
-			Type:          key.Type.String(),
-			PublicKey:     key.PublicKey,
-			Index:         key.Index,
-			SignPolicyId:  key.SignPolicyId,
+			Id:             key.Id,
+			WorkspaceAddr:  key.WorkspaceAddr,
+			KeyringAddr:    key.KeyringAddr,
+			Type:           key.Type.String(),
+			PublicKey:      key.PublicKey,
+			Index:          key.Index,
+			SignPolicyId:   key.SignPolicyId,
+			ZenbtcMetadata: key.ZenbtcMetadata,
 		},
 		Wallets: processWallets(key, req.WalletType, req.Prefixes),
 	}, nil

--- a/x/treasury/keeper/query_key_request_by_id.go
+++ b/x/treasury/keeper/query_key_request_by_id.go
@@ -34,6 +34,7 @@ func (k Keeper) KeyRequestByID(goCtx context.Context, req *types.QueryKeyRequest
 			RejectReason:           keyReq.RejectReason,
 			Index:                  keyReq.Index,
 			SignPolicyId:           keyReq.SignPolicyId,
+			ZenbtcMetadata:         keyReq.ZenbtcMetadata,
 		},
 	}, nil
 }

--- a/x/treasury/keeper/query_key_requests.go
+++ b/x/treasury/keeper/query_key_requests.go
@@ -39,6 +39,7 @@ func (k Keeper) KeyRequests(goCtx context.Context, req *types.QueryKeyRequestsRe
 				RejectReason:           value.RejectReason,
 				Index:                  value.Index,
 				SignPolicyId:           value.SignPolicyId,
+				ZenbtcMetadata:         value.ZenbtcMetadata,
 			}, nil
 		},
 	)

--- a/x/treasury/types/message_new_key_request.go
+++ b/x/treasury/types/message_new_key_request.go
@@ -8,7 +8,7 @@ import (
 
 var _ sdk.Msg = &MsgNewKeyRequest{}
 
-func NewMsgNewKeyRequest(creator string, workspaceAddr string, keyringAddr string, keyType string, btl uint64, signPolicyId uint64) *MsgNewKeyRequest {
+func NewMsgNewKeyRequest(creator, workspaceAddr, keyringAddr, keyType string, btl, signPolicyId uint64) *MsgNewKeyRequest {
 	return &MsgNewKeyRequest{
 		Creator:       creator,
 		WorkspaceAddr: workspaceAddr,


### PR DESCRIPTION
Some of the queries in `x/treasury/keeper` were missing `zenbtcMetadata` in their response. This PR adds them to harmonize key responses.