### PR TITLE
fix: bump zenbtc + cosmos fork vers, add extra logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.9.0
-	github.com/zenrocklabs/zenbtc v1.7.9
+	github.com/zenrocklabs/zenbtc v1.7.10
 	github.com/zenrocklabs/zenrock-avs v1.4.14
 	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c
 	golang.org/x/tools v0.26.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ replace (
 	cosmossdk.io/core => cosmossdk.io/core v0.11.0
 	github.com/Layr-Labs/eigensdk-go => github.com/zenrocklabs/eigensdk-go v0.1.7-zenrock2
 	github.com/btcsuite/btcd/btcec => github.com/btcsuite/btcd/btcec/v2 v2.0.0
-	github.com/cosmos/cosmos-sdk => github.com/zenrocklabs/cosmos-sdk v0.50.10-zenrock
+	github.com/cosmos/cosmos-sdk => github.com/zenrocklabs/cosmos-sdk v0.50.10-zenrock2
 	github.com/cosmos/iavl => github.com/cosmos/iavl v1.2.0
 	// fix upstream GHSA-h395-qcrw-5vmq vulnerability.
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.7.0
@@ -70,7 +70,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.9.0
-	github.com/zenrocklabs/zenbtc v1.7.8
+	github.com/zenrocklabs/zenbtc v1.7.9
 	github.com/zenrocklabs/zenrock-avs v1.4.14
 	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c
 	golang.org/x/tools v0.26.0

--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.9.0
-	github.com/zenrocklabs/zenbtc v1.7.10
+	github.com/zenrocklabs/zenbtc v1.7.11
 	github.com/zenrocklabs/zenrock-avs v1.4.14
 	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c
 	golang.org/x/tools v0.26.0

--- a/go.sum
+++ b/go.sum
@@ -1306,8 +1306,8 @@ github.com/zenrocklabs/cosmos-sdk v0.50.10-zenrock2 h1:AdQSOWitA063FzWTXboTKYjyt
 github.com/zenrocklabs/cosmos-sdk v0.50.10-zenrock2/go.mod h1:6Eesrx3ZE7vxBZWpK++30H+Uc7Q4ahQWCL7JKU/LEdU=
 github.com/zenrocklabs/eigensdk-go v0.1.7-zenrock2 h1:mip7GbIne2Aneeoe3MsaestQoqcXVA7LSXq/6ztw97Q=
 github.com/zenrocklabs/eigensdk-go v0.1.7-zenrock2/go.mod h1:ECU8/Ocsf+dGcN2rs8I1PScq4dOkQqY+vgwnq30Ov4M=
-github.com/zenrocklabs/zenbtc v1.7.10 h1:EYdmSBoSsJnP7u0Z03OtKpxUcEArGQPoZedqb5q5lNQ=
-github.com/zenrocklabs/zenbtc v1.7.10/go.mod h1:qG7DWuzWAchIlx0kjo33hdeNRlCnoWT58x/fS3HQyTg=
+github.com/zenrocklabs/zenbtc v1.7.11 h1:WJM4CnKJQJkBGt9or7vGPvbWjGq9ckcQzbGjmL4l4c8=
+github.com/zenrocklabs/zenbtc v1.7.11/go.mod h1:qG7DWuzWAchIlx0kjo33hdeNRlCnoWT58x/fS3HQyTg=
 github.com/zenrocklabs/zenrock-avs v1.4.14 h1:KOpx7SBk839s81+Icq4DqF84+AkP0ryBEOcNKKYubv0=
 github.com/zenrocklabs/zenrock-avs v1.4.14/go.mod h1:1TZzdlC+ZczhvS5tOc1ShRy2rwqHWhONd0dhB+GPTRE=
 github.com/zondax/hid v0.9.2 h1:WCJFnEDMiqGF64nlZz28E9qLVZ0KSJ7xpc5DLEyma2U=

--- a/go.sum
+++ b/go.sum
@@ -1302,12 +1302,12 @@ github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
-github.com/zenrocklabs/cosmos-sdk v0.50.10-zenrock h1:QKr8fWJ85qM/mcnKRQfsem6cNZ1hBmrnrv4FWt4cSmc=
-github.com/zenrocklabs/cosmos-sdk v0.50.10-zenrock/go.mod h1:6Eesrx3ZE7vxBZWpK++30H+Uc7Q4ahQWCL7JKU/LEdU=
+github.com/zenrocklabs/cosmos-sdk v0.50.10-zenrock2 h1:AdQSOWitA063FzWTXboTKYjytvfLyuPlBMYCR+/L7TQ=
+github.com/zenrocklabs/cosmos-sdk v0.50.10-zenrock2/go.mod h1:6Eesrx3ZE7vxBZWpK++30H+Uc7Q4ahQWCL7JKU/LEdU=
 github.com/zenrocklabs/eigensdk-go v0.1.7-zenrock2 h1:mip7GbIne2Aneeoe3MsaestQoqcXVA7LSXq/6ztw97Q=
 github.com/zenrocklabs/eigensdk-go v0.1.7-zenrock2/go.mod h1:ECU8/Ocsf+dGcN2rs8I1PScq4dOkQqY+vgwnq30Ov4M=
-github.com/zenrocklabs/zenbtc v1.7.8 h1:P6gKOgCpXlD8jKNzlXywHlALpcg+GePLkbUuyWGc+Pg=
-github.com/zenrocklabs/zenbtc v1.7.8/go.mod h1:kDN30IzNFN4fEAJZ6grwQk0v1YWm0lsleDo80UzFUA8=
+github.com/zenrocklabs/zenbtc v1.7.9 h1:iUO4Vw0niS2U7ZY+IVU6rrjpR1fbrmEFpsp2PioXWgM=
+github.com/zenrocklabs/zenbtc v1.7.9/go.mod h1:qG7DWuzWAchIlx0kjo33hdeNRlCnoWT58x/fS3HQyTg=
 github.com/zenrocklabs/zenrock-avs v1.4.14 h1:KOpx7SBk839s81+Icq4DqF84+AkP0ryBEOcNKKYubv0=
 github.com/zenrocklabs/zenrock-avs v1.4.14/go.mod h1:1TZzdlC+ZczhvS5tOc1ShRy2rwqHWhONd0dhB+GPTRE=
 github.com/zondax/hid v0.9.2 h1:WCJFnEDMiqGF64nlZz28E9qLVZ0KSJ7xpc5DLEyma2U=

--- a/go.sum
+++ b/go.sum
@@ -1306,8 +1306,8 @@ github.com/zenrocklabs/cosmos-sdk v0.50.10-zenrock2 h1:AdQSOWitA063FzWTXboTKYjyt
 github.com/zenrocklabs/cosmos-sdk v0.50.10-zenrock2/go.mod h1:6Eesrx3ZE7vxBZWpK++30H+Uc7Q4ahQWCL7JKU/LEdU=
 github.com/zenrocklabs/eigensdk-go v0.1.7-zenrock2 h1:mip7GbIne2Aneeoe3MsaestQoqcXVA7LSXq/6ztw97Q=
 github.com/zenrocklabs/eigensdk-go v0.1.7-zenrock2/go.mod h1:ECU8/Ocsf+dGcN2rs8I1PScq4dOkQqY+vgwnq30Ov4M=
-github.com/zenrocklabs/zenbtc v1.7.9 h1:iUO4Vw0niS2U7ZY+IVU6rrjpR1fbrmEFpsp2PioXWgM=
-github.com/zenrocklabs/zenbtc v1.7.9/go.mod h1:qG7DWuzWAchIlx0kjo33hdeNRlCnoWT58x/fS3HQyTg=
+github.com/zenrocklabs/zenbtc v1.7.10 h1:EYdmSBoSsJnP7u0Z03OtKpxUcEArGQPoZedqb5q5lNQ=
+github.com/zenrocklabs/zenbtc v1.7.10/go.mod h1:qG7DWuzWAchIlx0kjo33hdeNRlCnoWT58x/fS3HQyTg=
 github.com/zenrocklabs/zenrock-avs v1.4.14 h1:KOpx7SBk839s81+Icq4DqF84+AkP0ryBEOcNKKYubv0=
 github.com/zenrocklabs/zenrock-avs v1.4.14/go.mod h1:1TZzdlC+ZczhvS5tOc1ShRy2rwqHWhONd0dhB+GPTRE=
 github.com/zondax/hid v0.9.2 h1:WCJFnEDMiqGF64nlZz28E9qLVZ0KSJ7xpc5DLEyma2U=

--- a/x/validation/keeper/abci.go
+++ b/x/validation/keeper/abci.go
@@ -583,6 +583,8 @@ func (k *Keeper) processZenBTCMints(ctx sdk.Context, oracleData OracleData) {
 		}
 	}
 
+	k.Logger(ctx).Info("lastUsedNonce", "nonce", lastUsedNonce.Nonce, "counter", lastUsedNonce.Counter, "skip", lastUsedNonce.Skip, "requested_nonce", oracleData.RequestedEthMinterNonce)
+
 	if lastUsedNonce.Nonce != 0 && oracleData.RequestedEthMinterNonce == 0 {
 		return
 	}
@@ -591,12 +593,15 @@ func (k *Keeper) processZenBTCMints(ctx sdk.Context, oracleData OracleData) {
 
 	// remove last pending tx + update supply (after nonce updated indicating successful mint)
 	if oracleData.RequestedEthMinterNonce != lastUsedNonce.Nonce {
+		k.Logger(ctx).Warn("nonce updated", "nonce", oracleData.RequestedEthMinterNonce, "last_used_nonce", lastUsedNonce.Nonce)
+
 		supply, err := k.zenBTCKeeper.GetSupply(ctx)
 		if err != nil {
 			k.Logger(ctx).Error("error getting zenBTC supply", "err", err)
 		}
 
 		supply.MintedZenBTC += lastMintTx.Amount
+		k.Logger(ctx).Warn("minted supply updated", "minted_old", supply.MintedZenBTC-lastMintTx.Amount, "minted_new", supply.MintedZenBTC)
 
 		if err := k.zenBTCKeeper.SetSupply(ctx, supply); err != nil {
 			k.Logger(ctx).Error("error updating zenBTC supply", "err", err)


### PR DESCRIPTION
This PR updates the `x/zenbtc` version to resolve calculation issues and add extra logging. This PR also enables the `UpdateParams` CLI cmd for the `zenbtc` module and updates the forked `cosmos-sdk` version to fix the broken gov proposals query.