### PR TITLE
fix: track `PendingZenBTC` supply to use in exchange rate calc

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -4,11 +4,11 @@ import (
 	upgradetypes "cosmossdk.io/x/upgrade/types"
 
 	"github.com/Zenrock-Foundation/zrchain/v5/app/upgrades"
-	"github.com/Zenrock-Foundation/zrchain/v5/app/upgrades/v5temp4"
+	"github.com/Zenrock-Foundation/zrchain/v5/app/upgrades/v5temp5"
 )
 
 var Upgrades = []upgrades.Upgrade{
-	v5temp4.Upgrade,
+	v5temp5.Upgrade,
 }
 
 func (app ZenrockApp) RegisterUpgradeHandlers() {

--- a/app/upgrades/v5temp5/constants.go
+++ b/app/upgrades/v5temp5/constants.go
@@ -1,0 +1,18 @@
+package v5temp5
+
+import (
+	storetypes "cosmossdk.io/store/types"
+	"github.com/Zenrock-Foundation/zrchain/v5/app/upgrades"
+)
+
+const UpgradeName = "v5temp5"
+
+var Upgrade = upgrades.Upgrade{
+	UpgradeName:          UpgradeName,
+	CreateUpgradeHandler: CreateUpgradeHandler,
+	StoreUpgrades: storetypes.StoreUpgrades{
+		Added:   []string{},
+		Deleted: []string{},
+		Renamed: []storetypes.StoreRename{},
+	},
+}

--- a/app/upgrades/v5temp5/upgrade.go
+++ b/app/upgrades/v5temp5/upgrade.go
@@ -1,0 +1,19 @@
+package v5temp5
+
+import (
+	"context"
+
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+)
+
+func CreateUpgradeHandler(mm *module.Manager, configurator module.Configurator) upgradetypes.UpgradeHandler {
+	return func(context context.Context, _ upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+		ctx := sdk.UnwrapSDKContext(context)
+		logger := ctx.Logger().With("upgrade", UpgradeName)
+		logger.Debug("starting upgrade")
+
+		return mm.RunMigrations(ctx, configurator, vm)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.9.0
-	github.com/zenrocklabs/zenbtc v1.7.14
+	github.com/zenrocklabs/zenbtc v1.7.15
 	github.com/zenrocklabs/zenrock-avs v1.4.14
 	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c
 	golang.org/x/tools v0.26.0

--- a/go.sum
+++ b/go.sum
@@ -1306,8 +1306,8 @@ github.com/zenrocklabs/cosmos-sdk v0.50.10-zenrock2 h1:AdQSOWitA063FzWTXboTKYjyt
 github.com/zenrocklabs/cosmos-sdk v0.50.10-zenrock2/go.mod h1:6Eesrx3ZE7vxBZWpK++30H+Uc7Q4ahQWCL7JKU/LEdU=
 github.com/zenrocklabs/eigensdk-go v0.1.7-zenrock2 h1:mip7GbIne2Aneeoe3MsaestQoqcXVA7LSXq/6ztw97Q=
 github.com/zenrocklabs/eigensdk-go v0.1.7-zenrock2/go.mod h1:ECU8/Ocsf+dGcN2rs8I1PScq4dOkQqY+vgwnq30Ov4M=
-github.com/zenrocklabs/zenbtc v1.7.14 h1:An5dgOMxc8pWVteq6TCbm/tEqtMtOcY1ZMfVt4N6WZ4=
-github.com/zenrocklabs/zenbtc v1.7.14/go.mod h1:qG7DWuzWAchIlx0kjo33hdeNRlCnoWT58x/fS3HQyTg=
+github.com/zenrocklabs/zenbtc v1.7.15 h1:wzooh2sWe2pyvNkhAcGU+wO8hLGXuwJ2koK5rD4ms6g=
+github.com/zenrocklabs/zenbtc v1.7.15/go.mod h1:qG7DWuzWAchIlx0kjo33hdeNRlCnoWT58x/fS3HQyTg=
 github.com/zenrocklabs/zenrock-avs v1.4.14 h1:KOpx7SBk839s81+Icq4DqF84+AkP0ryBEOcNKKYubv0=
 github.com/zenrocklabs/zenrock-avs v1.4.14/go.mod h1:1TZzdlC+ZczhvS5tOc1ShRy2rwqHWhONd0dhB+GPTRE=
 github.com/zondax/hid v0.9.2 h1:WCJFnEDMiqGF64nlZz28E9qLVZ0KSJ7xpc5DLEyma2U=

--- a/x/validation/keeper/abci.go
+++ b/x/validation/keeper/abci.go
@@ -588,12 +588,15 @@ func (k *Keeper) processZenBTCMints(ctx sdk.Context, oracleData OracleData) {
 			k.Logger(ctx).Error("error getting zenBTC supply", "err", err)
 		}
 
+		supply.PendingZenBTC -= lastMintTx.Amount
 		supply.MintedZenBTC += lastMintTx.Amount
-		k.Logger(ctx).Warn("minted supply updated", "minted_old", supply.MintedZenBTC-lastMintTx.Amount, "minted_new", supply.MintedZenBTC)
 
 		if err := k.zenBTCKeeper.SetSupply(ctx, supply); err != nil {
 			k.Logger(ctx).Error("error updating zenBTC supply", "err", err)
 		}
+
+		k.Logger(ctx).Warn("pending mint supply updated", "pending_mint_old", supply.PendingZenBTC+lastMintTx.Amount, "pending_mint_new", supply.PendingZenBTC)
+		k.Logger(ctx).Warn("minted supply updated", "minted_old", supply.MintedZenBTC-lastMintTx.Amount, "minted_new", supply.MintedZenBTC)
 
 		pendingMints.Txs = pendingMints.Txs[1:]
 		if err := k.zenBTCKeeper.SetPendingMintTransactions(ctx, pendingMints); err != nil {


### PR DESCRIPTION
This PR tracks pending zenBTC supply to add it to minted zenBTC in the exchange rate's denominator, as the CustodiedBTC field (divisor) always includes deposits for pending mints.