### PR TITLE
fix: empty signreqs, testnet state, btc reorg depth

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -4,11 +4,11 @@ import (
 	upgradetypes "cosmossdk.io/x/upgrade/types"
 
 	"github.com/Zenrock-Foundation/zrchain/v5/app/upgrades"
-	"github.com/Zenrock-Foundation/zrchain/v5/app/upgrades/v5rev3"
+	"github.com/Zenrock-Foundation/zrchain/v5/app/upgrades/v5rev5"
 )
 
 var Upgrades = []upgrades.Upgrade{
-	v5rev3.Upgrade,
+	v5rev5.Upgrade,
 }
 
 func (app ZenrockApp) RegisterUpgradeHandlers() {

--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.9.0
-	github.com/zenrocklabs/zenbtc v1.8.0
+	github.com/zenrocklabs/zenbtc v1.9.3
 	github.com/zenrocklabs/zenrock-avs v1.4.14
 	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c
 	golang.org/x/tools v0.26.0
@@ -82,7 +82,10 @@ require (
 	gotest.tools/v3 v3.5.1
 )
 
-require github.com/cockroachdb/errors v1.11.3
+require (
+	github.com/cockroachdb/errors v1.11.3
+	github.com/test-go/testify v1.1.4
+)
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.34.1-20240508200655-46a4cf4ba109.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1306,8 +1306,8 @@ github.com/zenrocklabs/cosmos-sdk v0.50.10-zenrock h1:QKr8fWJ85qM/mcnKRQfsem6cNZ
 github.com/zenrocklabs/cosmos-sdk v0.50.10-zenrock/go.mod h1:6Eesrx3ZE7vxBZWpK++30H+Uc7Q4ahQWCL7JKU/LEdU=
 github.com/zenrocklabs/eigensdk-go v0.1.7-zenrock2 h1:mip7GbIne2Aneeoe3MsaestQoqcXVA7LSXq/6ztw97Q=
 github.com/zenrocklabs/eigensdk-go v0.1.7-zenrock2/go.mod h1:ECU8/Ocsf+dGcN2rs8I1PScq4dOkQqY+vgwnq30Ov4M=
-github.com/zenrocklabs/zenbtc v1.8.0 h1:Byk/6BZE7LtaqM2cSdCbC4PBxitVHRroJaBAgtWZlNU=
-github.com/zenrocklabs/zenbtc v1.8.0/go.mod h1:vW8q1xTipMQnQCWsqU1QfKBk/qpFC3HMav6Lq6906pM=
+github.com/zenrocklabs/zenbtc v1.9.3 h1:LEMuGmReXS7+7O2KmVPGZ5fGnZzeooHkegHH7eYi83o=
+github.com/zenrocklabs/zenbtc v1.9.3/go.mod h1:XXzwzMYs1p6Du6fIgBcAxUndEeVQc18qaTyBkHG8j7w=
 github.com/zenrocklabs/zenrock-avs v1.4.14 h1:KOpx7SBk839s81+Icq4DqF84+AkP0ryBEOcNKKYubv0=
 github.com/zenrocklabs/zenrock-avs v1.4.14/go.mod h1:1TZzdlC+ZczhvS5tOc1ShRy2rwqHWhONd0dhB+GPTRE=
 github.com/zondax/hid v0.9.2 h1:WCJFnEDMiqGF64nlZz28E9qLVZ0KSJ7xpc5DLEyma2U=

--- a/x/treasury/keeper/keeper.go
+++ b/x/treasury/keeper/keeper.go
@@ -448,9 +448,17 @@ func (k *Keeper) processSignatureRequests(ctx sdk.Context, dataForSigning [][]by
 }
 
 func (k *Keeper) HandleSignTransactionRequest(ctx sdk.Context, msg *types.MsgNewSignTransactionRequest, data []byte) (*types.MsgNewSignTransactionRequestResponse, error) {
+	if data == nil {
+		return nil, fmt.Errorf("data for signing is empty")
+	}
+
 	dataForSigning, err := dataForSigning(string(data))
 	if err != nil {
 		return nil, err
+	}
+
+	if len(dataForSigning) == 0 || dataForSigning[0] == nil {
+		return nil, fmt.Errorf("data for signing is empty")
 	}
 
 	keyIDs := []uint64{msg.KeyId}

--- a/x/treasury/keeper/migrator.go
+++ b/x/treasury/keeper/migrator.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	v2 "github.com/Zenrock-Foundation/zrchain/v5/x/treasury/migrations/v2"
+	v3 "github.com/Zenrock-Foundation/zrchain/v5/x/treasury/migrations/v3"
 	"github.com/Zenrock-Foundation/zrchain/v5/x/treasury/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -19,8 +20,18 @@ func NewMigrator(keeper Keeper) *Migrator {
 func (m Migrator) Migrate1to2(ctx sdk.Context) error {
 	ctx.Logger().With("module", types.ModuleName).Info("starting migration to v2")
 
-	err := v2.ChangeKeyIdtoKeyIds(ctx, m.keeper.SignRequestStore, m.keeper.cdc)
-	if err != nil {
+	if err := v2.ChangeKeyIdtoKeyIds(ctx, m.keeper.SignRequestStore, m.keeper.cdc); err != nil {
+		ctx.Logger().With("error", err).Error("failed to migrate treasury module")
+		return err
+	}
+
+	return nil
+}
+
+func (m Migrator) Migrate2to3(ctx sdk.Context) error {
+	ctx.Logger().With("module", types.ModuleName).Info("starting migration to v3")
+
+	if err := v3.RejectBadTestnetRequests(ctx, m.keeper.SignRequestStore, m.keeper.cdc); err != nil {
 		ctx.Logger().With("error", err).Error("failed to migrate treasury module")
 		return err
 	}

--- a/x/treasury/migrations/v3/migrations_test.go
+++ b/x/treasury/migrations/v3/migrations_test.go
@@ -1,0 +1,62 @@
+package v3_test
+
+import (
+	"testing"
+
+	"cosmossdk.io/collections"
+	storetypes "cosmossdk.io/store/types"
+	v3 "github.com/Zenrock-Foundation/zrchain/v5/x/treasury/migrations/v3"
+	treasury "github.com/Zenrock-Foundation/zrchain/v5/x/treasury/module"
+	"github.com/Zenrock-Foundation/zrchain/v5/x/treasury/types"
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/runtime"
+	"github.com/cosmos/cosmos-sdk/testutil"
+	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
+	"github.com/test-go/testify/require"
+)
+
+func TestMigrate(t *testing.T) {
+	encCfg := moduletestutil.MakeTestEncodingConfig(treasury.AppModuleBasic{})
+	cdc := encCfg.Codec
+
+	storeKey := storetypes.NewKVStoreKey(types.ModuleName)
+	tKey := storetypes.NewTransientStoreKey("transient_test")
+	ctx := testutil.DefaultContext(storeKey, tKey)
+
+	kvStoreService := runtime.NewKVStoreService(storeKey)
+	sb := collections.NewSchemaBuilder(kvStoreService)
+
+	signRequestStore := collections.NewMap(sb, types.SignRequestsKey, types.SignRequestsIndex, collections.Uint64Key, codec.CollValue[types.SignRequest](cdc))
+
+	req1 := types.SignRequest{
+		Id:             1,
+		DataForSigning: [][]byte{},
+		Status:         types.SignRequestStatus_SIGN_REQUEST_STATUS_PENDING,
+		Creator:        "zen13y3tm68gmu9kntcxwvmue82p6akacnpt2v7nty",
+		KeyId:          1,
+	}
+
+	req2 := types.SignRequest{
+		Id:             2,
+		DataForSigning: [][]byte{[]byte("to_be_signed_over")},
+		Status:         types.SignRequestStatus_SIGN_REQUEST_STATUS_PENDING,
+		Creator:        "zen13y3tm68gmu9kntcxwvmue82p6akacnpt2v7nty",
+		KeyId:          1,
+	}
+
+	err := signRequestStore.Set(ctx, req1.Id, req1)
+	require.NoError(t, err)
+	err = signRequestStore.Set(ctx, req2.Id, req2)
+	require.NoError(t, err)
+
+	require.NoError(t, v3.RejectBadTestnetRequests(ctx, signRequestStore, cdc))
+
+	migratedReq1, err := signRequestStore.Get(ctx, 1)
+	require.NoError(t, err)
+	require.Equal(t, types.SignRequestStatus_SIGN_REQUEST_STATUS_REJECTED, migratedReq1.Status)
+	require.Equal(t, "data for signing is empty", migratedReq1.RejectReason)
+
+	migratedReq2, err := signRequestStore.Get(ctx, 2)
+	require.NoError(t, err)
+	require.Equal(t, types.SignRequestStatus_SIGN_REQUEST_STATUS_PENDING, migratedReq2.Status)
+}

--- a/x/treasury/migrations/v3/store.go
+++ b/x/treasury/migrations/v3/store.go
@@ -1,0 +1,26 @@
+package v3
+
+import (
+	"cosmossdk.io/collections"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/Zenrock-Foundation/zrchain/v5/x/treasury/types"
+)
+
+func RejectBadTestnetRequests(ctx sdk.Context, signRequestStore collections.Map[uint64, types.SignRequest], codec codec.BinaryCodec) error {
+	if err := signRequestStore.Walk(ctx, nil, func(id uint64, signReq types.SignRequest) (bool, error) {
+		if signReq.DataForSigning == nil || signReq.DataForSigning[0] == nil {
+			signReq.Status = types.SignRequestStatus_SIGN_REQUEST_STATUS_REJECTED
+			signReq.RejectReason = "data for signing is empty"
+			if err := signRequestStore.Set(ctx, id, signReq); err != nil {
+				return true, err
+			}
+		}
+		return false, nil
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/x/treasury/module/module.go
+++ b/x/treasury/module/module.go
@@ -35,7 +35,7 @@ var (
 	_ porttypes.IBCModule       = IBCModule{}
 )
 
-const consensusVersion = 2
+const consensusVersion = 3
 
 // ----------------------------------------------------------------------------
 // AppModuleBasic
@@ -128,6 +128,10 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 	migrator := keeper.NewMigrator(am.keeper)
 	if err := cfg.RegisterMigration(types.ModuleName, 1, migrator.Migrate1to2); err != nil {
 		panic(fmt.Sprintf("failed to migrate x/%s from version 1 to 2: %v", types.ModuleName, err))
+	}
+
+	if err := cfg.RegisterMigration(types.ModuleName, 2, migrator.Migrate2to3); err != nil {
+		panic(fmt.Sprintf("failed to migrate x/%s from version 2 to 3: %v", types.ModuleName, err))
 	}
 }
 

--- a/x/validation/keeper/abci.go
+++ b/x/validation/keeper/abci.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"reflect"
 	"slices"
+	"strings"
 
 	"cosmossdk.io/collections"
 	"cosmossdk.io/math"
@@ -512,7 +513,7 @@ func (k *Keeper) storeBitcoinBlockHeader(ctx sdk.Context, oracleData OracleData)
 	}
 
 	if err := k.checkForBitcoinReorg(ctx, oracleData, requestedHeaders); err != nil {
-		k.Logger(ctx).Error("error handling potential Bitcoin fork", "height", oracleData.BtcBlockHeight, "err", err)
+		k.Logger(ctx).Error("error handling potential Bitcoin reorg", "height", oracleData.BtcBlockHeight, "err", err)
 	}
 }
 
@@ -522,8 +523,13 @@ func (k *Keeper) checkForBitcoinReorg(
 	oracleData OracleData,
 	requestedHeaders zenbtctypes.RequestedBitcoinHeaders,
 ) error {
-	prevHeights := make([]int64, 0, 6)
-	for i := int64(1); i <= 6; i++ {
+	var numHistoricalHeadersToRequest int64 = 20     // default for non-mainnet environments
+	if strings.HasPrefix(ctx.ChainID(), "diamond") { // mainnet
+		numHistoricalHeadersToRequest = 6
+	}
+
+	prevHeights := make([]int64, 0, numHistoricalHeadersToRequest)
+	for i := int64(1); i <= numHistoricalHeadersToRequest; i++ {
 		prevHeight := oracleData.BtcBlockHeight - i
 		if prevHeight <= 0 {
 			break
@@ -629,33 +635,40 @@ func (k *Keeper) processZenBTCMints(ctx sdk.Context, oracleData OracleData) {
 
 	pendingMintTx := pendingMints.Txs[0]
 
-	exchangeRate, err := k.zenBTCKeeper.GetExchangeRate(ctx)
-	if err != nil {
-		k.Logger(ctx).Error("error getting zenBTC exchange rate", "err", err)
-		return
-	}
+	// exchangeRate, err := k.zenBTCKeeper.GetExchangeRate(ctx)
+	// if err != nil {
+	// 	k.Logger(ctx).Error("error getting zenBTC exchange rate", "err", err)
+	// 	return
+	// }
 
-	feeZenBTC := k.CalculateZenBTCMintFee(
-		oracleData.EthBaseFee,
-		oracleData.EthTipCap,
-		oracleData.EthGasLimit,
-		oracleData.BTCUSDPrice,
-		oracleData.ETHUSDPrice,
-		exchangeRate,
-	)
+	// feeZenBTC := k.CalculateZenBTCMintFee(
+	// 	oracleData.EthBaseFee,
+	// 	oracleData.EthTipCap,
+	// 	oracleData.EthGasLimit,
+	// 	oracleData.BTCUSDPrice,
+	// 	oracleData.ETHUSDPrice,
+	// 	exchangeRate,
+	// )
 
 	if oracleData.BTCUSDPrice.IsZero() {
 		return
 	}
 
-	k.Logger(ctx).Warn("processing zenBTC mint", "recipient", pendingMintTx.RecipientAddress, "amount", pendingMintTx.Amount, "nonce", oracleData.RequestedEthMinterNonce, "gas_limit", oracleData.EthGasLimit, "base_fee", oracleData.EthBaseFee, "tip_cap", oracleData.EthTipCap)
+	k.Logger(ctx).Warn("processing zenBTC mint", "recipient", pendingMintTx.RecipientAddress, "amount", pendingMintTx.Amount, "nonce", oracleData.RequestedEthMinterNonce, "gas_limit", oracleData.EthGasLimit, "base_fee", oracleData.EthBaseFee, "tip_cap", oracleData.EthTipCap, "chain_id", pendingMintTx.ChainId)
+
+	// TODO: whitelist more chain IDs before mainnet upgrade
+	if pendingMintTx.ChainId != 17000 {
+		k.Logger(ctx).Error("invalid chain ID", "chain_id", pendingMintTx.ChainId)
+		return
+	}
 
 	unsignedMintTxHash, unsignedMintTx, err := k.constructMintTx(
 		ctx,
 		pendingMintTx.RecipientAddress,
 		pendingMintTx.ChainId,
 		pendingMintTx.Amount,
-		feeZenBTC,
+		// feeZenBTC,
+		0, // TODO: replace with feeZenBTC before mainnet upgrade
 		oracleData.RequestedEthMinterNonce,
 		oracleData.EthGasLimit,
 		oracleData.EthBaseFee,
@@ -841,7 +854,7 @@ func (k *Keeper) processZenBTCRedemptionsEthereum(ctx sdk.Context, oracleData Or
 	unsignedTxHash, unsignedTx, err := k.constructUnstakeTx(
 		ctx,
 		redemption.Data.Id,
-		17000, // TODO: make this dynamic
+		17000, // TODO: make this dynamic with a switch based on ctx.ChainID() before mainnet upgrade
 		oracleData.RequestedEthUnstakerNonce,
 		oracleData.EthBaseFee,
 		oracleData.EthTipCap,

--- a/x/validation/keeper/abci_utils.go
+++ b/x/validation/keeper/abci_utils.go
@@ -380,6 +380,7 @@ func (k *Keeper) lookupEthereumNonce(ctx context.Context, keyID uint64) (uint64,
 }
 
 func (k *Keeper) constructEthereumTx(ctx context.Context, chainID uint64, data []byte, nonce, gasLimit, baseFee, tipCap uint64) ([]byte, []byte, error) {
+	// TODO: whitelist more chain IDs before mainnet upgrade
 	if chainID != 17000 {
 		return nil, nil, fmt.Errorf("unsupported chain ID: %d", chainID)
 	}


### PR DESCRIPTION
This PR does the following:
- Adds validation to prevent sign requests with an empty `DataForSigning` field from being created
- Migration code to reject sign requests with empty `DataForSigning` fields
- Bumps zenBTC module to run migration to remove bad pending mint to non-Holesky chainIDs
- Increases reorg check of historical blocks to 20 for local/devnet/testnet envs (testnet4) leaving mainnet on 6