### PR TITLE
fix: treasury migration script

### DIFF
--- a/x/treasury/keeper/migrator.go
+++ b/x/treasury/keeper/migrator.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	v2 "github.com/Zenrock-Foundation/zrchain/v5/x/treasury/migrations/v2"
 	v3 "github.com/Zenrock-Foundation/zrchain/v5/x/treasury/migrations/v3"
+	v4 "github.com/Zenrock-Foundation/zrchain/v5/x/treasury/migrations/v4"
 	"github.com/Zenrock-Foundation/zrchain/v5/x/treasury/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -32,6 +33,17 @@ func (m Migrator) Migrate2to3(ctx sdk.Context) error {
 	ctx.Logger().With("module", types.ModuleName).Info("starting migration to v3")
 
 	if err := v3.RejectBadTestnetRequests(ctx, m.keeper.SignRequestStore, m.keeper.cdc); err != nil {
+		ctx.Logger().With("error", err).Error("failed to migrate treasury module")
+		return err
+	}
+
+	return nil
+}
+
+func (m Migrator) Migrate3to4(ctx sdk.Context) error {
+	ctx.Logger().With("module", types.ModuleName).Info("starting migration to v4")
+
+	if err := v4.RejectBadTestnetRequests(ctx, m.keeper.SignRequestStore, m.keeper.cdc); err != nil {
 		ctx.Logger().With("error", err).Error("failed to migrate treasury module")
 		return err
 	}

--- a/x/treasury/migrations/v4/migrations_test.go
+++ b/x/treasury/migrations/v4/migrations_test.go
@@ -1,0 +1,92 @@
+package v4_test
+
+import (
+	"testing"
+
+	"cosmossdk.io/collections"
+	storetypes "cosmossdk.io/store/types"
+	v4 "github.com/Zenrock-Foundation/zrchain/v5/x/treasury/migrations/v4"
+	treasury "github.com/Zenrock-Foundation/zrchain/v5/x/treasury/module"
+	"github.com/Zenrock-Foundation/zrchain/v5/x/treasury/types"
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/runtime"
+	"github.com/cosmos/cosmos-sdk/testutil"
+	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
+	"github.com/test-go/testify/require"
+)
+
+func TestMigrate(t *testing.T) {
+	encCfg := moduletestutil.MakeTestEncodingConfig(treasury.AppModuleBasic{})
+	cdc := encCfg.Codec
+
+	storeKey := storetypes.NewKVStoreKey(types.ModuleName)
+	tKey := storetypes.NewTransientStoreKey("transient_test")
+	ctx := testutil.DefaultContext(storeKey, tKey)
+
+	kvStoreService := runtime.NewKVStoreService(storeKey)
+	sb := collections.NewSchemaBuilder(kvStoreService)
+
+	signRequestStore := collections.NewMap(sb, types.SignRequestsKey, types.SignRequestsIndex, collections.Uint64Key, codec.CollValue[types.SignRequest](cdc))
+
+	req1 := types.SignRequest{
+		Id:             1,
+		DataForSigning: [][]byte{},
+		Status:         types.SignRequestStatus_SIGN_REQUEST_STATUS_PENDING,
+		Creator:        "zen13y3tm68gmu9kntcxwvmue82p6akacnpt2v7nty",
+		KeyId:          1,
+	}
+
+	req2 := types.SignRequest{
+		Id:             2,
+		DataForSigning: [][]byte{[]byte("to_be_signed_over")},
+		Status:         types.SignRequestStatus_SIGN_REQUEST_STATUS_PENDING,
+		Creator:        "zen13y3tm68gmu9kntcxwvmue82p6akacnpt2v7nty",
+		KeyId:          1,
+	}
+
+	req3 := types.SignRequest{
+		Id:             3,
+		DataForSigning: [][]byte{[]byte("")},
+		Status:         types.SignRequestStatus_SIGN_REQUEST_STATUS_REJECTED,
+		Creator:        "zen13y3tm68gmu9kntcxwvmue82p6akacnpt2v7nty",
+		KeyId:          1,
+	}
+
+	req4 := types.SignRequest{
+		Id:             4,
+		DataForSigning: [][]byte{},
+		Status:         types.SignRequestStatus_SIGN_REQUEST_STATUS_PENDING,
+		Creator:        "zen13y3tm68gmu9kntcxwvmue82p6akacnpt2v7nty",
+		KeyId:          1,
+	}
+
+	err := signRequestStore.Set(ctx, req1.Id, req1)
+	require.NoError(t, err)
+	err = signRequestStore.Set(ctx, req2.Id, req2)
+	require.NoError(t, err)
+	err = signRequestStore.Set(ctx, req3.Id, req3)
+	require.NoError(t, err)
+	err = signRequestStore.Set(ctx, req4.Id, req4)
+	require.NoError(t, err)
+
+	require.NoError(t, v4.RejectBadTestnetRequests(ctx, signRequestStore, cdc))
+
+	migratedReq1, err := signRequestStore.Get(ctx, 1)
+	require.NoError(t, err)
+	require.Equal(t, types.SignRequestStatus_SIGN_REQUEST_STATUS_REJECTED, migratedReq1.Status)
+	require.Equal(t, "data for signing is empty", migratedReq1.RejectReason)
+
+	migratedReq2, err := signRequestStore.Get(ctx, 2)
+	require.NoError(t, err)
+	require.Equal(t, types.SignRequestStatus_SIGN_REQUEST_STATUS_PENDING, migratedReq2.Status)
+
+	migratedReq3, err := signRequestStore.Get(ctx, 3)
+	require.NoError(t, err)
+	require.Equal(t, types.SignRequestStatus_SIGN_REQUEST_STATUS_REJECTED, migratedReq3.Status)
+	require.Equal(t, "data for signing is empty", migratedReq3.RejectReason)
+
+	migratedReq4, err := signRequestStore.Get(ctx, 4)
+	require.NoError(t, err)
+	require.Equal(t, types.SignRequestStatus_SIGN_REQUEST_STATUS_REJECTED, migratedReq4.Status)
+	require.Equal(t, "data for signing is empty", migratedReq4.RejectReason)
+}

--- a/x/treasury/migrations/v4/store.go
+++ b/x/treasury/migrations/v4/store.go
@@ -1,0 +1,26 @@
+package v4
+
+import (
+	"cosmossdk.io/collections"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/Zenrock-Foundation/zrchain/v5/x/treasury/types"
+)
+
+func RejectBadTestnetRequests(ctx sdk.Context, signRequestStore collections.Map[uint64, types.SignRequest], codec codec.BinaryCodec) error {
+	if err := signRequestStore.Walk(ctx, nil, func(id uint64, signReq types.SignRequest) (bool, error) {
+		if len(signReq.DataForSigning) == 0 || len(signReq.DataForSigning[0]) == 0 {
+			signReq.Status = types.SignRequestStatus_SIGN_REQUEST_STATUS_REJECTED
+			signReq.RejectReason = "data for signing is empty"
+			if err := signRequestStore.Set(ctx, id, signReq); err != nil {
+				return true, err
+			}
+		}
+		return false, nil
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/x/treasury/module/module.go
+++ b/x/treasury/module/module.go
@@ -35,7 +35,7 @@ var (
 	_ porttypes.IBCModule       = IBCModule{}
 )
 
-const consensusVersion = 3
+const consensusVersion = 4
 
 // ----------------------------------------------------------------------------
 // AppModuleBasic
@@ -132,6 +132,10 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 
 	if err := cfg.RegisterMigration(types.ModuleName, 2, migrator.Migrate2to3); err != nil {
 		panic(fmt.Sprintf("failed to migrate x/%s from version 2 to 3: %v", types.ModuleName, err))
+	}
+
+	if err := cfg.RegisterMigration(types.ModuleName, 3, migrator.Migrate3to4); err != nil {
+		panic(fmt.Sprintf("failed to migrate x/%s from version 3 to 4: %v", types.ModuleName, err))
 	}
 }
 


### PR DESCRIPTION
This PR fixes the treasury migration script attempted in `v3` and rejects pending signature requests with empty request string.