### PR TITLE
fix: wasmvm version in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN echo "building service: ${service_name}, version: ${version}, build date: ${
 
 
 # Add libwasmvm for musl
-ENV WASMVM_VERSION=v2.1.3
+ENV WASMVM_VERSION=v2.1.5
 ADD https://github.com/CosmWasm/wasmvm/releases/download/$WASMVM_VERSION/libwasmvm_muslc.aarch64.a /lib/libwasmvm_muslc.aarch64.a
 ADD https://github.com/CosmWasm/wasmvm/releases/download/$WASMVM_VERSION/libwasmvm_muslc.x86_64.a /lib/libwasmvm_muslc.x86_64.a
 RUN sha256sum /lib/libwasmvm_muslc.aarch64.a | grep faea4e15390e046d2ca8441c21a88dba56f9a0363f92c5d94015df0ac6da1f2d

--- a/sidecar/Dockerfile
+++ b/sidecar/Dockerfile
@@ -21,7 +21,7 @@ ENV version=$VERSION
 RUN echo "building service: ${service_name}, version: ${version}, build date: ${build_date}, commit hash: ${commit_hash}, architecture: ${arch}"
 
 # Add libwasmvm for musl
-ENV WASMVM_VERSION=v2.1.3
+ENV WASMVM_VERSION=v2.1.5
 ADD https://github.com/CosmWasm/wasmvm/releases/download/$WASMVM_VERSION/libwasmvm_muslc.aarch64.a /lib/libwasmvm_muslc.aarch64.a
 ADD https://github.com/CosmWasm/wasmvm/releases/download/$WASMVM_VERSION/libwasmvm_muslc.x86_64.a /lib/libwasmvm_muslc.x86_64.a
 RUN sha256sum /lib/libwasmvm_muslc.aarch64.a | grep faea4e15390e046d2ca8441c21a88dba56f9a0363f92c5d94015df0ac6da1f2d


### PR DESCRIPTION
This PR fixes the semantic release creation by using the correct `wasmvm v2.1.5`  in the dockerfiles.