### PR TITLE
fix: added flags for pulsar and python generation

### DIFF
--- a/scripts/pulsargen.sh
+++ b/scripts/pulsargen.sh
@@ -2,6 +2,11 @@
 set -euo pipefail
 IFS=$'\n\t'
 
+# Only proceed if --pulsar flag is provided
+if [[ "$*" != *"--pulsar"* ]]; then
+	exit 0
+fi
+
 if ! command -v protoc-gen-go-pulsar &>/dev/null; then
 	echo "Error: protoc-gen-go-pulsar is not installed. Please install it before proceeding."
 	echo "go install github.com/cosmos/cosmos-proto/cmd/protoc-gen-go-pulsar"
@@ -11,11 +16,8 @@ fi
 echo "Script executed from: ${PWD}"
 project_root_dir=$(git rev-parse --show-toplevel)
 echo "Generating proto pulsar code"
-proto_root=$project_root_dir/zrchain
 
-pushd .
-cd "$proto_root"
-buf generate -v --template "$project_root_dir"/zrchain/proto/buf.gen.pulsar.yaml
-popd
+# Run buf generate command
+buf generate -v --template "$project_root_dir/proto/buf.gen.pulsar.yaml"
 
 echo "Pulsar files generated."


### PR DESCRIPTION
The makefile has been changed so that we create python and pulsar files only when providing the correct flag for it. 

`make proto `                 - Generate Go protobuf files only
`make proto PYTHON_GEN=true`  - Generate Go and Python protobuf files
`make proto PULSAR_GEN=true`  - Generate Go and Pulsar protobuf files
`make proto PYTHON_GEN=true PULSAR_GEN=true`  - Generate all protobuf files (Go, Python, and Pulsar)
