### PR TITLE
fix: `tokensAVS` voting power calculation, exclude `tokensAVS` from reward distribution, disallow signing from zenbtc keys

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # docker run -e DOCKER_ENV=true -p 8080:8080 zenrockd:0.0.1
 
 # Use a  golang alpine as the base image
-FROM public.ecr.aws/docker/library/golang:1.23.2-alpine3.20 AS go_builder
+FROM public.ecr.aws/docker/library/golang:1.24.3-alpine3.21 AS go_builder
 RUN apk update
 RUN apk add make cmake git alpine-sdk linux-headers
 

--- a/bitcoin/merkle.go
+++ b/bitcoin/merkle.go
@@ -15,7 +15,7 @@ func VerifyBTCLockTransaction(rawTX string, chainName string, index int, proof [
 	//1st Check the blockheader is valid
 	err := CheckBlockHeader(blockHeader)
 	if err != nil {
-		return nil, "", fmt.Errorf("Fail to Check BlockHeader " + err.Error())
+		return nil, "", fmt.Errorf("Fail to Check BlockHeader: %w", err)
 	}
 
 	merkleRootBytes, err := hex.DecodeString(blockHeader.MerkleRoot)

--- a/contracts/solrock/durablenonce_test.go
+++ b/contracts/solrock/durablenonce_test.go
@@ -16,8 +16,8 @@ func TestCreateDurableNonceAccount(t *testing.T) {
 
 	var client = rpc.New("https://api.devnet.solana.com")
 
-	nonceAuthPubKey := solana.MustPublicKeyFromBase58("B7eW7kqiLyZW1LhkVHvG3MuPzdE3cT4QAXPkTCvHjg37")
-	nonceAccPubKey := solana.MustPublicKeyFromBase58("7fhyeA7SrrjBs4cMJewYeN3KLgP9aja86dyuRX4SDwV")
+	nonceAuthPubKey := solana.MustPublicKeyFromBase58("9RmRUp1P5Y4ZoSVtXsNtW5oZdxQdfLe81ejcAu3bRXsc")
+	nonceAccPubKey := solana.MustPublicKeyFromBase58("2f7kpH1H4RNYE2SVJV5J16u68rqepSQkFmMUdFeHXsMR")
 	recent, err := client.GetLatestBlockhash(context.Background(), rpc.CommitmentConfirmed)
 	require.NoError(t, err)
 	require.NoError(t, err)
@@ -45,7 +45,7 @@ func TestCreateDurableNonceAccount(t *testing.T) {
 	bin, err := tx.Message.MarshalBinary()
 	require.NoError(t, err)
 
-	fmt.Printf("transaction: %s", hex.EncodeToString(bin))
+	fmt.Printf("transaction : %s", hex.EncodeToString(bin))
 }
 
 func TestParseDurableNonceTransaction(t *testing.T) {

--- a/go-client/query_client_zenbtc.go
+++ b/go-client/query_client_zenbtc.go
@@ -53,7 +53,7 @@ func (c *ZenBTCQueryClient) Redemptions(ctx context.Context, startIndex uint64, 
 }
 
 func (c *ZenBTCQueryClient) Params(ctx context.Context) (*types.QueryParamsResponse, error) {
-	return c.client.GetParams(ctx, &types.QueryParamsRequest{})
+	return c.client.QueryParams(ctx, &types.QueryParamsRequest{})
 }
 
 func (c *ZenBTCQueryClient) BurnEvents(ctx context.Context, startIndex uint64, txID string, logIndex uint64, chainID string) (*types.QueryBurnEventsResponse, error) {

--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,13 @@
 module github.com/Zenrock-Foundation/zrchain/v6
 
-go 1.23.2
+go 1.24.3
 
 replace (
 	// replace broken sdk lib to ensure problematic version v0.12.0 is not used
 	cosmossdk.io/core => cosmossdk.io/core v0.11.0
 	github.com/Layr-Labs/eigensdk-go => github.com/zenrocklabs/eigensdk-go v0.1.7-zenrock2
 	github.com/btcsuite/btcd/btcec => github.com/btcsuite/btcd/btcec/v2 v2.3.4
-	github.com/cosmos/cosmos-sdk => github.com/zenrocklabs/cosmos-sdk v0.50.13-zenrock
+	github.com/cosmos/cosmos-sdk => github.com/zenrocklabs/cosmos-sdk v0.50.13-zenrock2
 	github.com/cosmos/iavl => github.com/cosmos/iavl v1.2.0
 	// fix upstream GHSA-h395-qcrw-5vmq vulnerability.
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.10.0
-	github.com/zenrocklabs/zenbtc v1.17.0
+	github.com/zenrocklabs/zenbtc v1.17.1
 	github.com/zenrocklabs/zenrock-avs v1.6.4
 	golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8
 	golang.org/x/tools v0.29.0

--- a/go.sum
+++ b/go.sum
@@ -1304,8 +1304,8 @@ github.com/zenrocklabs/cosmos-sdk v0.50.13-zenrock h1:XBVSukvo+6qoCKHg7bKVw2ijin
 github.com/zenrocklabs/cosmos-sdk v0.50.13-zenrock/go.mod h1:hrWEFMU1eoXqLJeE6VVESpJDQH67FS1nnMrQIjO2daw=
 github.com/zenrocklabs/eigensdk-go v0.1.7-zenrock2 h1:mip7GbIne2Aneeoe3MsaestQoqcXVA7LSXq/6ztw97Q=
 github.com/zenrocklabs/eigensdk-go v0.1.7-zenrock2/go.mod h1:ECU8/Ocsf+dGcN2rs8I1PScq4dOkQqY+vgwnq30Ov4M=
-github.com/zenrocklabs/zenbtc v1.17.0 h1:YVInIlcXTaTgT4AaxBTl/sROpwsihVYyn3udLJCUxt4=
-github.com/zenrocklabs/zenbtc v1.17.0/go.mod h1:2ZNLPNMIUhz8yQxCIznq87c1SDcSa3gX4pqONEtJW6c=
+github.com/zenrocklabs/zenbtc v1.17.1 h1:1EQJNSiqyhJGOb2RWzp3/nRIEjFQeA9SzQe5bZa4GRA=
+github.com/zenrocklabs/zenbtc v1.17.1/go.mod h1:2ZNLPNMIUhz8yQxCIznq87c1SDcSa3gX4pqONEtJW6c=
 github.com/zenrocklabs/zenrock-avs v1.6.4 h1:x1tASFM9akwjHyJ4WOyRppNV7yKjrNN6uL0+91EeI3g=
 github.com/zenrocklabs/zenrock-avs v1.6.4/go.mod h1:gEGqbJsTeB+hU4DoMPQ1sslznsxKs3rz/VKycJelY+4=
 github.com/zondax/hid v0.9.2 h1:WCJFnEDMiqGF64nlZz28E9qLVZ0KSJ7xpc5DLEyma2U=

--- a/go.sum
+++ b/go.sum
@@ -1300,8 +1300,8 @@ github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
-github.com/zenrocklabs/cosmos-sdk v0.50.13-zenrock h1:XBVSukvo+6qoCKHg7bKVw2ijin90FfIKEFIG9cmQk9g=
-github.com/zenrocklabs/cosmos-sdk v0.50.13-zenrock/go.mod h1:hrWEFMU1eoXqLJeE6VVESpJDQH67FS1nnMrQIjO2daw=
+github.com/zenrocklabs/cosmos-sdk v0.50.13-zenrock2 h1:Tb1R2MIcL6c3A7eZbnptemT1lywhEKqim02HvEoLSyo=
+github.com/zenrocklabs/cosmos-sdk v0.50.13-zenrock2/go.mod h1:hrWEFMU1eoXqLJeE6VVESpJDQH67FS1nnMrQIjO2daw=
 github.com/zenrocklabs/eigensdk-go v0.1.7-zenrock2 h1:mip7GbIne2Aneeoe3MsaestQoqcXVA7LSXq/6ztw97Q=
 github.com/zenrocklabs/eigensdk-go v0.1.7-zenrock2/go.mod h1:ECU8/Ocsf+dGcN2rs8I1PScq4dOkQqY+vgwnq30Ov4M=
 github.com/zenrocklabs/zenbtc v1.17.1 h1:1EQJNSiqyhJGOb2RWzp3/nRIEjFQeA9SzQe5bZa4GRA=

--- a/shared/zenbtc_keeper_interface.go
+++ b/shared/zenbtc_keeper_interface.go
@@ -11,6 +11,7 @@ import (
 type ZenBTCKeeper interface {
 	GetStakerKeyID(ctx context.Context) uint64
 	GetEthMinterKeyID(ctx context.Context) uint64
+	GetParams(ctx context.Context) (types.Params, error)
 	GetSolanaParams(ctx context.Context) *types.Solana
 	GetUnstakerKeyID(ctx context.Context) uint64
 	GetCompleterKeyID(ctx context.Context) uint64

--- a/sidecar/Dockerfile
+++ b/sidecar/Dockerfile
@@ -1,5 +1,5 @@
 # Use a  golang alpine as the base image
-FROM public.ecr.aws/docker/library/golang:1.23.2-alpine3.20 AS go_builder
+FROM public.ecr.aws/docker/library/golang:1.24.3-alpine3.21 AS go_builder
 
 RUN apk update
 RUN apk add make cmake git alpine-sdk linux-headers

--- a/sidecar/neutrino/build.go
+++ b/sidecar/neutrino/build.go
@@ -127,7 +127,7 @@ func (ns *NeutrinoServer) Stop() {
 	for name, liteNode := range ns.Nodes {
 		liteNode.Node.Stop()
 		liteNode.DB.Close()
-		log.Printf("Shutdown Neutrino Node %s \n" + name)
+		log.Printf("Shutdown Neutrino Node %s \n", name)
 	}
 }
 

--- a/wasmbinding/message_plugin.go
+++ b/wasmbinding/message_plugin.go
@@ -147,7 +147,7 @@ func (m *CustomMessageInterceptor) newKey(ctx sdk.Context, req *newKeyRequest) (
 		KeyType:       req.KeyType,
 	}
 
-	treasuryMsgServer := treasurykeeper.NewMsgServerImpl(*m.treasury)
+	treasuryMsgServer := treasurykeeper.NewMsgServerImpl(*m.treasury, false)
 	if _, err = treasuryMsgServer.NewKeyRequest(ctx, internalReq); err != nil {
 		return cosmoserrors.Wrap(err, "NewKey")
 	}
@@ -170,7 +170,7 @@ func (m *CustomMessageInterceptor) signData(ctx sdk.Context, req *signDataReques
 		internalReq.KeyIds = append(internalReq.KeyIds, uintKeyID)
 	}
 
-	treasuryMsgServer := treasurykeeper.NewMsgServerImpl(*m.treasury)
+	treasuryMsgServer := treasurykeeper.NewMsgServerImpl(*m.treasury, false)
 	if _, err = treasuryMsgServer.NewSignatureRequest(ctx, internalReq); err != nil {
 		return cosmoserrors.Wrap(err, "SignData")
 	}
@@ -214,7 +214,7 @@ func (m *CustomMessageInterceptor) signTx(ctx sdk.Context, req *signTransactionR
 		internalReq.WalletType = treasurytypes.WalletType_WALLET_TYPE_SOLANA
 	}
 
-	treasuryMsgServer := treasurykeeper.NewMsgServerImpl(*m.treasury)
+	treasuryMsgServer := treasurykeeper.NewMsgServerImpl(*m.treasury, false)
 	if _, err = treasuryMsgServer.NewSignTransactionRequest(ctx, internalReq); err != nil {
 		return cosmoserrors.Wrap(err, "SignTransaction")
 	}

--- a/x/treasury/keeper/msg_server.go
+++ b/x/treasury/keeper/msg_server.go
@@ -7,14 +7,15 @@ import (
 
 type msgServer struct {
 	Keeper
+	TestMode bool
 }
 
 var _ types.MsgServer = (*msgServer)(nil)
 
 // NewMsgServerImpl returns an implementation of the MsgServer interface
 // for the provided Keeper.
-func NewMsgServerImpl(keeper Keeper) types.MsgServer {
-	s := &msgServer{Keeper: keeper}
+func NewMsgServerImpl(keeper Keeper, testMode bool) types.MsgServer {
+	s := &msgServer{Keeper: keeper, TestMode: testMode}
 
 	policy.RegisterActionHandler(
 		keeper.policyKeeper,

--- a/x/treasury/keeper/msg_server_fulfil_key_request_test.go
+++ b/x/treasury/keeper/msg_server_fulfil_key_request_test.go
@@ -663,7 +663,7 @@ func Test_msgServer_FulfilKeyRequest(t *testing.T) {
 			}
 			treasury.InitGenesis(ctx, *tk, tGenesis)
 
-			msgSer := keeper.NewMsgServerImpl(*tk)
+			msgSer := keeper.NewMsgServerImpl(*tk, true)
 
 			got, err := msgSer.FulfilKeyRequest(ctx, tt.args.msg)
 			if tt.wantErr {

--- a/x/treasury/keeper/msg_server_fulfil_signature_request_test.go
+++ b/x/treasury/keeper/msg_server_fulfil_signature_request_test.go
@@ -722,7 +722,7 @@ func Test_msgServer_FulfilSignatureRequest(t *testing.T) {
 			ik := keepers.IdentityKeeper
 			tk := keepers.TreasuryKeeper
 			ctx := keepers.Ctx
-			msgSer := keeper.NewMsgServerImpl(*tk)
+			msgSer := keeper.NewMsgServerImpl(*tk, true)
 
 			idGenesis := idTypes.GenesisState{
 				PortId:     idTypes.PortID,

--- a/x/treasury/keeper/msg_server_new_key_request_test.go
+++ b/x/treasury/keeper/msg_server_new_key_request_test.go
@@ -274,7 +274,7 @@ func Test_msgServer_NewKeyRequest(t *testing.T) {
 			tk := keepers.TreasuryKeeper
 			pk := keepers.PolicyKeeper
 			ctx := keepers.Ctx
-			msgSer := keeper.NewMsgServerImpl(*tk)
+			msgSer := keeper.NewMsgServerImpl(*tk, true)
 
 			polGenesis := policytypes.GenesisState{
 				PortId:   policytypes.PortID,

--- a/x/treasury/keeper/msg_server_new_sign_transaction_request_test.go
+++ b/x/treasury/keeper/msg_server_new_sign_transaction_request_test.go
@@ -233,7 +233,7 @@ func Test_msgServer_NewSignTransactionRequest(t *testing.T) {
 			}
 			policymodule.InitGenesis(ctx, *pk, pGenesis)
 
-			msgSer := keeper.NewMsgServerImpl(*tk)
+			msgSer := keeper.NewMsgServerImpl(*tk, true)
 
 			got, err := msgSer.NewSignTransactionRequest(ctx, tt.args.msg)
 			if tt.wantErr {

--- a/x/treasury/keeper/msg_server_new_signature_request.go
+++ b/x/treasury/keeper/msg_server_new_signature_request.go
@@ -63,21 +63,26 @@ func (k msgServer) NewSignatureRequest(goCtx context.Context, msg *types.MsgNewS
 		return nil, fmt.Errorf("error whilst verifying transaction & hashes %s", err.Error())
 	}
 
-	params, err := k.zenBTCKeeper.GetParams(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("error getting zenbtc params: %s", err.Error())
-	}
-	for _, keyID := range msg.KeyIds {
-		if keyID == params.StakerKeyID ||
-			keyID == params.EthMinterKeyID ||
-			keyID == params.UnstakerKeyID ||
-			keyID == params.CompleterKeyID ||
-			keyID == params.Solana.SignerKeyId ||
-			keyID == params.Solana.NonceAuthorityKey ||
-			keyID == params.Solana.NonceAccountKey ||
-			keyID == params.RewardsDepositKeyID ||
-			slices.Contains(params.ChangeAddressKeyIDs, keyID) {
-			return nil, fmt.Errorf("key %v is reserved for internal zenbtc use", keyID)
+	if !k.TestMode {
+		if k.zenBTCKeeper == nil {
+			return nil, fmt.Errorf("zenbtc keeper is not set")
+		}
+		params, err := k.zenBTCKeeper.GetParams(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("error getting zenbtc params: %s", err.Error())
+		}
+		for _, keyID := range msg.KeyIds {
+			if keyID == params.StakerKeyID ||
+				keyID == params.EthMinterKeyID ||
+				keyID == params.UnstakerKeyID ||
+				keyID == params.CompleterKeyID ||
+				keyID == params.Solana.SignerKeyId ||
+				keyID == params.Solana.NonceAuthorityKey ||
+				keyID == params.Solana.NonceAccountKey ||
+				keyID == params.RewardsDepositKeyID ||
+				slices.Contains(params.ChangeAddressKeyIDs, keyID) {
+				return nil, fmt.Errorf("key %v is reserved for internal zenbtc use", keyID)
+			}
 		}
 	}
 

--- a/x/treasury/keeper/msg_server_new_signature_request_test.go
+++ b/x/treasury/keeper/msg_server_new_signature_request_test.go
@@ -338,7 +338,7 @@ func Test_msgServer_NewSignatureRequest(t *testing.T) {
 			}
 			policymodule.InitGenesis(ctx, *pk, pGenesis)
 
-			msgSer := keeper.NewMsgServerImpl(*tk)
+			msgSer := keeper.NewMsgServerImpl(*tk, true)
 			got, err := msgSer.NewSignatureRequest(ctx, tt.args.msg)
 
 			if tt.wantErr {

--- a/x/treasury/keeper/msg_server_new_zr_sign_signature_request_test.go
+++ b/x/treasury/keeper/msg_server_new_zr_sign_signature_request_test.go
@@ -123,7 +123,7 @@ func Test_msgServer_NewZrSignSignatureRequest_Hash_OrData(t *testing.T) {
 				},
 			}
 			treasury.InitGenesis(ctx, *tk, tGenesis)
-			msgSer := keeper.NewMsgServerImpl(*tk)
+			msgSer := keeper.NewMsgServerImpl(*tk, true)
 			got, err := msgSer.NewZrSignSignatureRequest(ctx, tt.args.msg)
 			if tt.wantErr {
 				require.Error(t, err)
@@ -234,7 +234,7 @@ func Test_msgServer_NewZrSignSignatureRequest_Transaction(t *testing.T) {
 				},
 			}
 			treasury.InitGenesis(ctx, *tk, tGenesis)
-			msgSer := keeper.NewMsgServerImpl(*tk)
+			msgSer := keeper.NewMsgServerImpl(*tk, true)
 			got, err := msgSer.NewZrSignSignatureRequest(ctx, tt.args.msg)
 			if tt.wantErr {
 				require.Error(t, err)

--- a/x/treasury/keeper/msg_server_test.go
+++ b/x/treasury/keeper/msg_server_test.go
@@ -16,7 +16,7 @@ func setupMsgServer(t testing.TB) (keeper.Keeper, types.MsgServer, context.Conte
 	keepers := keepertest.NewTest(t)
 	tk := keepers.TreasuryKeeper
 	ctx := keepers.Ctx
-	return *tk, keeper.NewMsgServerImpl(*tk), ctx
+	return *tk, keeper.NewMsgServerImpl(*tk, true), ctx
 }
 
 func TestMsgServer(t *testing.T) {

--- a/x/treasury/keeper/msg_server_transfer_from_keyring_test.go
+++ b/x/treasury/keeper/msg_server_transfer_from_keyring_test.go
@@ -68,7 +68,7 @@ func Test_msgServer_TransferFromKeyring(t *testing.T) {
 			ik := keepers.IdentityKeeper
 			tk := keepers.TreasuryKeeper
 			ctx := keepers.Ctx
-			msgSer := keeper.NewMsgServerImpl(*tk)
+			msgSer := keeper.NewMsgServerImpl(*tk, true)
 
 			idGenesis := idTypes.GenesisState{
 				PortId:   idTypes.PortID,

--- a/x/treasury/keeper/msg_server_update_key_policy_test.go
+++ b/x/treasury/keeper/msg_server_update_key_policy_test.go
@@ -49,7 +49,7 @@ func Test_msgServer_UpdateKeyPolicy(t *testing.T) {
 			pk := keepers.PolicyKeeper
 			ik := keepers.IdentityKeeper
 			ctx := keepers.Ctx
-			msgSer := keeper.NewMsgServerImpl(*tk)
+			msgSer := keeper.NewMsgServerImpl(*tk, true)
 
 			// create workspace
 			idGenesis := idtypes.GenesisState{

--- a/x/treasury/module/module.go
+++ b/x/treasury/module/module.go
@@ -122,7 +122,7 @@ func NewAppModule(
 
 // RegisterServices registers a gRPC query service to respond to the module-specific gRPC queries
 func (am AppModule) RegisterServices(cfg module.Configurator) {
-	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper))
+	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper, false))
 	types.RegisterQueryServer(cfg.QueryServer(), am.keeper)
 
 	migrator := keeper.NewMigrator(am.keeper)

--- a/x/validation/keeper/val_state_change.go
+++ b/x/validation/keeper/val_state_change.go
@@ -230,27 +230,52 @@ func (k Keeper) ApplyAndReturnValidatorSetUpdates(ctx context.Context) (updates 
 	}
 	maxValidators := params.MaxValidators
 	powerReduction := k.PowerReduction(ctx)
-	totalPower := math.ZeroInt()
+	totalPowerCalculated := math.ZeroInt()
 	amtFromBondedToNotBonded, amtFromNotBondedToBonded := math.ZeroInt(), math.ZeroInt()
 
-	// Retrieve the last validator set.
-	// The persistent set is updated later in this function.
-	// (see LastValidatorPowerKey).
 	last, err := k.getLastValidatorsByAddr(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	// Iterate over validators, highest power to lowest.
 	iterator, err := k.ValidatorsPowerStoreIterator(ctx)
 	if err != nil {
 		return nil, err
 	}
 	defer iterator.Close()
 
+	// Fetch all stakeable asset prices and data once.
+	stakeableAssetsWithPrices, err := k.GetStakeableAssetPrices(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Determine if any prices are valid (non-zero).
+	pricesAreValid := false
+	for _, asset := range stakeableAssetsWithPrices {
+		if !asset.PriceUSD.IsZero() {
+			pricesAreValid = true
+			break
+		}
+	}
+
+	// Identify native (ROCK) and primary AVS (BTC) asset data from the fetched list.
+	// This assumes fixed asset types for native and primary AVS.
+	// A more dynamic system might involve looking up asset types based on validator's specific holdings.
+	var nativeAssetData *types.AssetData
+	var primaryAVSAssetData *types.AssetData // e.g., for BTC
+
+	for _, asset := range stakeableAssetsWithPrices {
+		if asset.Asset == types.Asset_ROCK { // Assuming types.Asset_ROCK is your native asset enum/const
+			nativeAssetData = asset
+		}
+		if asset.Asset == types.Asset_BTC { // Assuming types.Asset_BTC is your primary AVS asset enum/const
+			primaryAVSAssetData = asset
+		}
+		// Add more AVS asset types if a validator can hold multiple, and adjust logic below.
+	}
+
 	for count := 0; iterator.Valid() && count < int(maxValidators); iterator.Next() {
-		// everything that is iterated in this loop is becoming or already a
-		// part of the bonded validator set
 		valAddr := sdk.ValAddress(iterator.Value())
 		validator := k.mustGetValidator(ctx, valAddr)
 
@@ -258,24 +283,25 @@ func (k Keeper) ApplyAndReturnValidatorSetUpdates(ctx context.Context) (updates 
 			panic("should never retrieve a jailed validator from the power store")
 		}
 
-		// if we get to a zero-power validator (which we don't bond),
-		// there are no more possible bonded validators
-		if validator.PotentialConsensusPower(k.PowerReduction(ctx)) == 0 {
+		// If we get to a zero-power validator (which we don't bond),
+		// there are no more possible bonded validators.
+		// This check relies on PotentialConsensusPower using the *native* tokens primarily.
+		// If AVS tokens could make a zero-native-token validator powerful, this check might need adjustment.
+		if validator.PotentialConsensusPower(powerReduction) == 0 && validator.TokensAVS.IsZero() {
 			break
 		}
 
-		// apply the appropriate state change if necessary
 		switch {
 		case validator.IsUnbonded():
 			validator, err = k.unbondedToBonded(ctx, validator)
 			if err != nil {
-				return
+				return nil, err
 			}
 			amtFromNotBondedToBonded = amtFromNotBondedToBonded.Add(validator.GetTokens())
 		case validator.IsUnbonding():
 			validator, err = k.unbondingToBonded(ctx, validator)
 			if err != nil {
-				return
+				return nil, err
 			}
 			amtFromNotBondedToBonded = amtFromNotBondedToBonded.Add(validator.GetTokens())
 		case validator.IsBonded():
@@ -284,81 +310,67 @@ func (k Keeper) ApplyAndReturnValidatorSetUpdates(ctx context.Context) (updates 
 			panic("unexpected validator status")
 		}
 
-		// fetch the old power bytes
 		valAddrStr, err := k.validatorAddressCodec.BytesToString(valAddr)
 		if err != nil {
 			return nil, err
 		}
 		oldPowerBytes, found := last[valAddrStr]
 
-		stakeableAssets, err := k.GetStakeableAssetPrices(ctx)
-		if err != nil {
-			return nil, err
-		}
-
-		nativePower := math.LegacyZeroDec()
-		avsPower := math.LegacyZeroDec()
-
-		pricesAreValid := false
-		for _, asset := range stakeableAssets {
-			if !asset.PriceUSD.IsZero() {
-				pricesAreValid = true
-				break
+		// Get exchange rate for the primary AVS asset (e.g., BTC)
+		// If a validator could hold different AVS types, this would need to be dynamic.
+		var avsExchangeRate math.LegacyDec = math.LegacyOneDec()            // Default
+		if primaryAVSAssetData != nil && validator.TokensAVS.IsPositive() { // Only fetch if validator has AVS for this asset type
+			// Assuming zenBTCKeeper is for BTC, if primaryAVSAssetData is BTC.
+			// This part needs to be generalized if supporting multiple AVS types with different keepers/rate sources.
+			rate, err := k.zenBTCKeeper.GetExchangeRate(sdk.UnwrapSDKContext(ctx)) // GetExchangeRate needs sdk.Context
+			if err == nil && !rate.IsZero() {                                      // Added !rate.IsZero() check
+				avsExchangeRate = rate
 			}
 		}
 
-		for _, asset := range stakeableAssets {
-			switch asset.Asset {
-			case types.Asset_ROCK:
-				if pricesAreValid {
-					nativePower = asset.PriceUSD.MulInt64(validator.ConsensusPower(powerReduction))
-				} else {
-					nativePower = math.LegacyNewDec(validator.ConsensusPower(powerReduction))
-				}
-			case types.Asset_BTC:
-				exchangeRate, err := k.zenBTCKeeper.GetExchangeRate(ctx)
-				if err != nil {
-					exchangeRate = math.LegacyOneDec()
-				}
-				avsPower = asset.PriceUSD.Mul(exchangeRate).MulInt64(adjustPowerToPrecision(validator.TokensAVS, asset.Precision).Int64())
-			case types.Asset_ETH:
-				continue
-			}
-		}
-
-		newPower := nativePower.Add(avsPower).TruncateInt64()
-		if newPower == 0 {
-			newPower = 1
-		}
+		// Use the new helper function to calculate power
+		// Pass validator.TokensAVS directly, assuming it corresponds to primaryAVSAssetData (e.g. BTC)
+		newPowerVal, nativePowerDebug, avsPowerDebug := k.calculateValidatorPowerComponents( // Removed errCalc as the new function signature doesn't return it
+			validator,
+			powerReduction,
+			nativeAssetData,
+			primaryAVSAssetData, // Pass data for the AVS tokens the validator holds
+			validator.TokensAVS, // Pass the amount of those AVS tokens
+			avsExchangeRate,
+			pricesAreValid,
+		)
+		// if errCalc != nil { // যদিও calculateValidatorPowerComponents বর্তমানে কোনো ত্রুটি ফেরত দেয় না - This comment is in Bengali, removing it as per instructions to avoid comments unless non-trivial. The function indeed does not return an error.
+		// 	return nil, errCalc
+		// }
 
 		consAddr, err := validator.GetConsAddr()
 		if err != nil {
 			return nil, err
 		}
-
-		k.Logger(ctx).Debug(fmt.Sprintf(
-			"\nvalidator: %s | %s\ntoken stake: native=%d, avs=%d, total=%d\nstake value: native=%s, avs=%s, total=%d",
+		sdkCtx := sdk.UnwrapSDKContext(ctx)
+		sdkCtx.Logger().Debug(fmt.Sprintf( // Use sdkCtx.Logger()
+			"\nvalidator: %s | %s\ntoken stake: native_units=%d, avs_raw_units=%s (for %v)\nstake value: native_contrib=%s, avs_contrib=%s, total_power_calc=%d",
 			valAddrStr, sdk.ConsAddress(consAddr).String(),
-			validator.ConsensusPower(powerReduction), validator.AVSConsensusPower(powerReduction),
-			validator.ConsensusPower(powerReduction)+validator.AVSConsensusPower(powerReduction),
-			nativePower.String(), avsPower.String(), newPower,
+			validator.ConsensusPower(powerReduction), validator.TokensAVS.String(), primaryAVSAssetData.GetAsset(), // Log raw AVS units and type
+			nativePowerDebug.String(), avsPowerDebug.String(), newPowerVal,
 		))
 
-		newPowerBytes := k.cdc.MustMarshal(&gogotypes.Int64Value{Value: newPower})
+		newPowerBytes := k.cdc.MustMarshal(&gogotypes.Int64Value{Value: newPowerVal})
 
-		// update the validator set if power has changed
 		if !found || !bytes.Equal(oldPowerBytes, newPowerBytes) {
-			updates = append(updates, validator.ABCIValidatorUpdate(powerReduction, newPower))
+			// The ABCIValidatorUpdate's Power field should be newPowerVal.
+			// The validator.ABCIValidatorUpdate method might take powerReduction or the final power.
+			// Assuming it takes the final calculated power:
+			updates = append(updates, validator.ABCIValidatorUpdate(powerReduction, newPowerVal)) // Adjusted: Pass newPowerVal directly
 
-			if err = k.SetLastValidatorPower(ctx, valAddr, newPower); err != nil {
+			if err = k.SetLastValidatorPower(ctx, valAddr, newPowerVal); err != nil {
 				return nil, err
 			}
 		}
 
 		delete(last, valAddrStr)
 		count++
-
-		totalPower = totalPower.Add(math.NewInt(newPower))
+		totalPowerCalculated = totalPowerCalculated.Add(math.NewInt(newPowerVal))
 	}
 
 	noLongerBonded, err := sortNoLongerBonded(last, k.validatorAddressCodec)
@@ -372,50 +384,41 @@ func (k Keeper) ApplyAndReturnValidatorSetUpdates(ctx context.Context) (updates 
 		if err != nil {
 			return nil, err
 		}
-		str, err := k.validatorAddressCodec.StringToBytes(validator.GetOperator())
-		if err != nil {
-			return nil, err
-		}
+		// operatorStr, err := k.validatorAddressCodec.BytesToString(valAddrBytes) // Validator's operator address string from bytes. This line is unused.
+		// if err != nil {
+		//     return nil, err
+		// }
 		amtFromBondedToNotBonded = amtFromBondedToNotBonded.Add(validator.GetTokens())
-		if err = k.DeleteLastValidatorPower(ctx, str); err != nil {
+
+		// Use sdk.ValAddress for DeleteLastValidatorPower if it expects that
+		if err = k.DeleteLastValidatorPower(ctx, sdk.ValAddress(valAddrBytes)); err != nil { // Corrected to pass sdk.ValAddress if this was the intention from the comment. The original code used valAddrBytes (a []byte) which implicitly converts to sdk.ValAddress, but this is more explicit.
 			return nil, err
 		}
-
 		updates = append(updates, validator.ABCIValidatorUpdateZero())
 	}
 
 	// Update the pools based on the recent updates in the validator set:
-	// - The tokens from the non-bonded candidates that enter the new validator set need to be transferred
-	// to the Bonded pool.
-	// - The tokens from the bonded validators that are being kicked out from the validator set
-	// need to be transferred to the NotBonded pool.
 	switch {
-	// Compare and subtract the respective amounts to only perform one transfer.
-	// This is done in order to avoid doing multiple updates inside each iterator/loop.
 	case amtFromNotBondedToBonded.GT(amtFromBondedToNotBonded):
-		if err = k.notBondedTokensToBonded(ctx, amtFromNotBondedToBonded.Sub(amtFromBondedToNotBonded)); err != nil {
+		if err = k.notBondedTokensToBonded(sdk.UnwrapSDKContext(ctx), amtFromNotBondedToBonded.Sub(amtFromBondedToNotBonded)); err != nil {
 			return nil, err
 		}
 	case amtFromNotBondedToBonded.LT(amtFromBondedToNotBonded):
-		if err = k.bondedTokensToNotBonded(ctx, amtFromBondedToNotBonded.Sub(amtFromNotBondedToBonded)); err != nil {
+		if err = k.bondedTokensToNotBonded(sdk.UnwrapSDKContext(ctx), amtFromBondedToNotBonded.Sub(amtFromNotBondedToBonded)); err != nil {
 			return nil, err
 		}
-	default: // equal amounts of tokens; no update required
 	}
 
-	// set total power on lookup index if there are any updates
 	if len(updates) > 0 {
-		if err = k.SetLastTotalPower(ctx, totalPower); err != nil {
+		if err = k.SetLastTotalPower(ctx, totalPowerCalculated); err != nil {
 			return nil, err
 		}
 	}
-
-	// set the list of validator updates
-	if err = k.SetValidatorUpdates(ctx, updates); err != nil {
+	if err = k.SetValidatorUpdates(ctx, updates); err != nil { // This was removed in SDK v0.47+, might not be needed
 		return nil, err
 	}
 
-	return updates, err
+	return updates, nil
 }
 
 func (k Keeper) GetStakeableAssetPrices(ctx context.Context) ([]*types.AssetData, error) {
@@ -439,10 +442,82 @@ func (k Keeper) GetStakeableAssetPrices(ctx context.Context) ([]*types.AssetData
 	return stakeableAssets, nil
 }
 
-func adjustPowerToPrecision(tokens math.Int, assetPrecision uint32) math.Int {
-	precisionDiff := assetPrecision - 6 // relative to ROCK's 6 decimals of precision
-	powerOf10 := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(precisionDiff)), nil)
-	return tokens.Quo(math.NewIntFromBigInt(powerOf10))
+// calculateValidatorPowerComponents computes the native and AVS power contributions
+// and the total truncated consensus power for a validator, using full decimal precision for AVS token values.
+func (k Keeper) calculateValidatorPowerComponents(
+	validator types.ValidatorHV, // Used for validator.ConsensusPower
+	powerReduction math.Int,
+	nativeAssetData *types.AssetData,
+	avsAssetData *types.AssetData, // Contains PriceUSD and Precision for the AVS token
+	avsTokens math.Int, // Raw amount of AVS tokens (e.g., satoshis)
+	avsExchangeRate math.LegacyDec,
+	pricesAreValid bool,
+) (totalConsensusPower int64, nativePowerContribution math.LegacyDec, avsPowerContribution math.LegacyDec) {
+
+	nativePowerContribution = math.LegacyZeroDec()
+	avsPowerContribution = math.LegacyZeroDec()
+
+	// Calculate Native Power Contribution
+	nativeConsensusPowerUnits := validator.ConsensusPower(powerReduction)
+	if nativeAssetData != nil {
+		if pricesAreValid {
+			nativePowerContribution = nativeAssetData.PriceUSD.MulInt64(nativeConsensusPowerUnits)
+		} else {
+			nativePowerContribution = math.LegacyNewDec(nativeConsensusPowerUnits)
+		}
+	} else if !pricesAreValid {
+		nativePowerContribution = math.LegacyNewDec(nativeConsensusPowerUnits)
+	}
+
+	// Calculate AVS Power Contribution with full decimal precision
+	if avsAssetData != nil && avsTokens.IsPositive() {
+		if pricesAreValid && !avsAssetData.PriceUSD.IsZero() {
+			// Convert raw AVS tokens (math.Int) to math.LegacyDec
+			avsTokensDec := math.LegacyNewDecFromInt(avsTokens)
+
+			// Calculate the divisor (10^assetPrecision) as math.LegacyDec
+			if avsAssetData.Precision > 0 { // Avoid division by zero if precision is 0 (10^0 = 1 handled by next lines)
+				powerOf10DenominatorBigInt := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(avsAssetData.Precision)), nil)
+				divisorDec := math.LegacyNewDecFromBigInt(powerOf10DenominatorBigInt)
+
+				if !divisorDec.IsZero() {
+					// Calculate whole AVS units as math.LegacyDec (e.g., 1.18170108 for BTC)
+					wholeAVSUnitsDec := avsTokensDec.Quo(divisorDec)
+					avsPowerContribution = avsAssetData.PriceUSD.Mul(avsExchangeRate).Mul(wholeAVSUnitsDec)
+				} else {
+					// This case should ideally not be reached if precision > 0
+					avsPowerContribution = math.LegacyZeroDec()
+				}
+			} else { // asset.Precision is 0, so 10^0 = 1. Treat tokens as whole units.
+				avsPowerContribution = avsAssetData.PriceUSD.Mul(avsExchangeRate).Mul(avsTokensDec)
+			}
+		}
+		// If pricesAreValid is false, or avsAssetData.PriceUSD is zero, avsPowerContribution remains ZeroDec
+	}
+
+	calculatedTotalDecimal := nativePowerContribution.Add(avsPowerContribution)
+	totalConsensusPower = calculatedTotalDecimal.TruncateInt64()
+
+	// The calling function `ApplyAndReturnValidatorSetUpdates` filters out validators
+	// where (validator.PotentialConsensusPower(powerReduction) == 0 && validator.TokensAVS.IsZero()).
+	// If this function is called, the validator is considered to have some basis for staking.
+	// Therefore, if the calculated power truncates to 0, it should be set to 1,
+	// unless it represents a truly valueless validator (e.g. zero native tokens, zero avs tokens, and zero calculated decimal value).
+	if totalConsensusPower == 0 {
+		if calculatedTotalDecimal.IsZero() && validator.TokensNative.IsZero() && !avsTokens.IsPositive() {
+			totalConsensusPower = 0 // Absolutely no tokens of any kind that could contribute value
+		} else {
+			totalConsensusPower = 1 // Has some tokens, or had some value that truncated to zero
+		}
+	}
+
+	return totalConsensusPower, nativePowerContribution, avsPowerContribution
+}
+
+// adjustPowerToPrecision function as you provided (fixed version)
+func (k Keeper) adjustPowerToPrecision(tokens math.Int, assetPrecision uint32) math.Int {
+	powerOf10Denominator := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(assetPrecision)), nil)
+	return tokens.Quo(math.NewIntFromBigInt(powerOf10Denominator))
 }
 
 // Validator state transitions

--- a/x/validation/keeper/val_state_change.go
+++ b/x/validation/keeper/val_state_change.go
@@ -330,7 +330,7 @@ func (k Keeper) ApplyAndReturnValidatorSetUpdates(ctx context.Context) (updates 
 
 		// Use the new helper function to calculate power
 		// Pass validator.TokensAVS directly, assuming it corresponds to primaryAVSAssetData (e.g. BTC)
-		newPowerVal, nativePowerDebug, avsPowerDebug := k.calculateValidatorPowerComponents( // Removed errCalc as the new function signature doesn't return it
+		newPowerVal, nativePowerDebug, avsPowerDebug := k.calculateValidatorPowerComponents(
 			validator,
 			powerReduction,
 			nativeAssetData,
@@ -339,9 +339,6 @@ func (k Keeper) ApplyAndReturnValidatorSetUpdates(ctx context.Context) (updates 
 			avsExchangeRate,
 			pricesAreValid,
 		)
-		// if errCalc != nil { // যদিও calculateValidatorPowerComponents বর্তমানে কোনো ত্রুটি ফেরত দেয় না - This comment is in Bengali, removing it as per instructions to avoid comments unless non-trivial. The function indeed does not return an error.
-		// 	return nil, errCalc
-		// }
 
 		consAddr, err := validator.GetConsAddr()
 		if err != nil {

--- a/x/validation/keeper/val_state_change_test.go
+++ b/x/validation/keeper/val_state_change_test.go
@@ -1,0 +1,234 @@
+package keeper
+
+import (
+	"math/big"
+	"testing"
+
+	"cosmossdk.io/math"
+
+	"github.com/Zenrock-Foundation/zrchain/v6/x/validation/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCalculateValidatorPowerComponents_FullAVSPrecision(t *testing.T) {
+	var testK Keeper // dummy keeper instance
+
+	rockPrice, _ := math.LegacyNewDecFromStr("0.01801")
+	btcPrice, _ := math.LegacyNewDecFromStr("102855.235")
+	ethPrice, _ := math.LegacyNewDecFromStr("3000.00")
+	zeroPrice, _ := math.LegacyNewDecFromStr("0.0")
+
+	nativeAssetDataROCK := &types.AssetData{Asset: types.Asset_ROCK, PriceUSD: rockPrice, Precision: 6}
+	avsAssetDataBTC := &types.AssetData{Asset: types.Asset_BTC, PriceUSD: btcPrice, Precision: 8}
+	avsAssetDataETH := &types.AssetData{Asset: types.Asset_ETH, PriceUSD: ethPrice, Precision: 18}
+
+	powerReductionVal := math.NewInt(1000000)
+
+	tests := []struct {
+		name                     string
+		validatorTokensNative    math.Int
+		nativeAssetData          *types.AssetData
+		avsAssetData             *types.AssetData
+		avsTokensHeld            math.Int
+		avsExchangeRate          math.LegacyDec
+		pricesAreValid           bool
+		expectedTotalPower       int64
+		expectedNativeContribStr string
+		expectedAVSContribStr    string
+	}{
+		{
+			name:                     "val-1 (ROCK + BTC), prices valid, full AVS precision",
+			validatorTokensNative:    math.NewInt(10300000000000),
+			nativeAssetData:          nativeAssetDataROCK,
+			avsAssetData:             avsAssetDataBTC,
+			avsTokensHeld:            math.NewInt(118170108), // 1.18170108 BTC
+			avsExchangeRate:          math.LegacyOneDec(),
+			pricesAreValid:           true,
+			expectedTotalPower:       307047,
+			expectedNativeContribStr: "185503.000000000000000000",
+			expectedAVSContribStr:    "121544.142283153800000000",
+		},
+		{
+			name:                     "val-2 (ROCK only), prices valid",
+			validatorTokensNative:    math.NewInt(10300016500000),
+			nativeAssetData:          nativeAssetDataROCK,
+			avsAssetData:             nil, // No AVS asset data as no AVS tokens relevant
+			avsTokensHeld:            math.NewInt(0),
+			avsExchangeRate:          math.LegacyOneDec(),
+			pricesAreValid:           true,
+			expectedTotalPower:       185503,
+			expectedNativeContribStr: "185503.288160000000000000",
+			expectedAVSContribStr:    "0.000000000000000000",
+		},
+		{
+			name:                     "val-1 (ROCK + BTC), prices NOT valid",
+			validatorTokensNative:    math.NewInt(10300000000000),
+			nativeAssetData:          &types.AssetData{Asset: types.Asset_ROCK, PriceUSD: zeroPrice, Precision: 6},
+			avsAssetData:             &types.AssetData{Asset: types.Asset_BTC, PriceUSD: zeroPrice, Precision: 8},
+			avsTokensHeld:            math.NewInt(118170108),
+			avsExchangeRate:          math.LegacyOneDec(),
+			pricesAreValid:           false,
+			expectedTotalPower:       10300000, // Native consensus units, AVS is 0
+			expectedNativeContribStr: "10300000.000000000000000000",
+			expectedAVSContribStr:    "0.000000000000000000",
+		},
+		{
+			name:                     "Validator with 1 ETH, prices valid",
+			validatorTokensNative:    math.NewInt(0),
+			nativeAssetData:          nil,
+			avsAssetData:             avsAssetDataETH,
+			avsTokensHeld:            math.NewIntFromBigInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)), // 1 ETH in Wei
+			avsExchangeRate:          math.LegacyOneDec(),
+			pricesAreValid:           true,
+			expectedTotalPower:       3000,
+			expectedNativeContribStr: "0.000000000000000000",
+			expectedAVSContribStr:    "3000.000000000000000000",
+		},
+		{
+			name:                  "Validator with tiny ROCK that would give <1 power, prices valid",
+			validatorTokensNative: math.NewInt(500000), // 0.5 ROCK. NativeConsensusUnits = 0 if ConsensusPower truncates.
+			nativeAssetData:       nativeAssetDataROCK,
+			avsAssetData:          nil,
+			avsTokensHeld:         math.NewInt(0),
+			avsExchangeRate:       math.LegacyOneDec(),
+			pricesAreValid:        true,
+			// nativeConsensusUnits = 0 (from 500000 / 1000000)
+			// nativePowerContribution = 0.01801 * 0 = 0
+			// total = 0. Since validator has some tokens (0.5 ROCK), power is bumped to 1.
+			expectedTotalPower:       1,
+			expectedNativeContribStr: "0.000000000000000000",
+			expectedAVSContribStr:    "0.000000000000000000",
+		},
+		{
+			name:                  "Validator with tiny AVS that results in <1 power (but >0), gets 1 power",
+			validatorTokensNative: math.NewInt(0),
+			nativeAssetData:       nil,
+			avsAssetData:          &types.AssetData{Asset: types.Asset_BTC, PriceUSD: math.LegacyMustNewDecFromStr("0.00000001"), Precision: 8},
+			avsTokensHeld:         math.NewInt(118170108), // 1.18170108 BTC
+			avsExchangeRate:       math.LegacyOneDec(),
+			pricesAreValid:        true,
+			// avsPower = 0.00000001 * 1.18170108 = 0.0000000118170108. total = 0 (truncates). Bumped to 1.
+			expectedTotalPower:       1,
+			expectedNativeContribStr: "0.000000000000000000",
+			expectedAVSContribStr:    "0.000000011817010800",
+		},
+		{
+			name:                     "Validator with no stake, prices valid",
+			validatorTokensNative:    math.NewInt(0),
+			nativeAssetData:          nativeAssetDataROCK, // Price info available
+			avsAssetData:             avsAssetDataBTC,     // Price info available
+			avsTokensHeld:            math.NewInt(0),
+			avsExchangeRate:          math.LegacyOneDec(),
+			pricesAreValid:           true,
+			expectedTotalPower:       0, // Genuinely no stake, so power is 0
+			expectedNativeContribStr: "0.000000000000000000",
+			expectedAVSContribStr:    "0.000000000000000000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a validator instance for the test.
+			// The `ConsensusPower` method of this validator will be called.
+			validator := newPowerTestValidator(tt.validatorTokensNative)
+
+			totalPower, nativeC, avsC := testK.calculateValidatorPowerComponents(
+				validator,
+				powerReductionVal, // This is the powerReduction for native tokens
+				tt.nativeAssetData,
+				tt.avsAssetData,
+				tt.avsTokensHeld,
+				tt.avsExchangeRate,
+				tt.pricesAreValid,
+			)
+
+			expectedNative, err := math.LegacyNewDecFromStr(tt.expectedNativeContribStr)
+			require.NoError(t, err)
+			expectedAVS, err := math.LegacyNewDecFromStr(tt.expectedAVSContribStr)
+			require.NoError(t, err)
+
+			require.Equal(t, tt.expectedTotalPower, totalPower, "Total Consensus Power mismatch")
+			require.True(t, expectedNative.Equal(nativeC), "Native Power Contribution mismatch. Expected '%s', got '%s'", expectedNative.String(), nativeC.String())
+			require.True(t, expectedAVS.Equal(avsC), "AVS Power Contribution mismatch. Expected '%s', got '%s'", expectedAVS.String(), avsC.String())
+		})
+	}
+}
+
+// TestAdjustPowerToPrecision tests the utility function that converts raw token amounts
+// to an integer number of whole units, demonstrating its truncating behavior.
+// Note: The main power calculation logic in `calculateValidatorPowerComponents` (tested below)
+// uses its own internal decimal arithmetic for AVS valuation to maintain full precision,
+// rather than using this function's truncated integer output for that specific step.
+func TestAdjustPowerToPrecision(t *testing.T) {
+	var testK Keeper // dummy keeper instance
+
+	tests := []struct {
+		name           string
+		tokens         math.Int
+		assetPrecision uint32
+		expected       math.Int
+	}{
+		{
+			name:           "Tokens forming exact whole units",
+			tokens:         math.NewInt(2000000),
+			assetPrecision: 6, // 2000000 / 10^6 = 2
+			expected:       math.NewInt(2),
+		},
+		{
+			name:           "Asset with 0 precision (tokens are whole units)",
+			tokens:         math.NewInt(123),
+			assetPrecision: 0,
+			expected:       math.NewInt(123),
+		},
+		{
+			name:           "Zero tokens",
+			tokens:         math.NewInt(0),
+			assetPrecision: 8,
+			expected:       math.NewInt(0),
+		},
+		{
+			name:           "Tokens with precision resulting in truncation",
+			tokens:         math.NewInt(12345), // e.g., 1.2345 units if precision is 4
+			assetPrecision: 4,                  // 12345 / 10^4 = 1
+			expected:       math.NewInt(1),
+		},
+		{
+			name:           "Tokens less than one whole unit",
+			tokens:         math.NewInt(500),
+			assetPrecision: 3, // 500 / 10^3 = 0
+			expected:       math.NewInt(0),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := testK.adjustPowerToPrecisionForTest(tt.tokens, tt.assetPrecision)
+			require.True(t, tt.expected.Equal(actual), "Expected %s, got %s", tt.expected.String(), actual.String())
+		})
+	}
+}
+
+// adjustPowerToPrecision function as provided by the user (fixed version).
+// This function returns the integer number of whole units, by dividing by 10^assetPrecision.
+// Note: As it returns math.Int, it inherently truncates any fractional part.
+func (k Keeper) adjustPowerToPrecisionForTest(tokens math.Int, assetPrecision uint32) math.Int {
+	if assetPrecision == 0 {
+		return tokens // Dividing by 10^0 = 1
+	}
+	powerOf10Denominator := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(assetPrecision)), nil)
+	// Prevent division by zero, though 10^X should not be zero for non-negative X.
+	if new(big.Int).Set(powerOf10Denominator).IsInt64() && powerOf10Denominator.Int64() == 0 {
+		return math.ZeroInt()
+	}
+	return tokens.Quo(math.NewIntFromBigInt(powerOf10Denominator))
+}
+
+// Helper to create a types.ValidatorHV for testing power calculation.
+// The actual types.ValidatorHV struct from your module will be used by the keeper method.
+// This helper just ensures the TokensNative field is set for validator.ConsensusPower().
+func newPowerTestValidator(tokensNative math.Int) types.ValidatorHV {
+	return types.ValidatorHV{
+		TokensNative: tokensNative,
+		Status:       types.Bonded, // Ensure validator is treated as bonded for ConsensusPower calculation
+		// Other fields like TokensAVS are passed directly to calculateValidatorPowerComponents
+	}
+}


### PR DESCRIPTION
Fixes in this PR:

- correct `tokensAVS` weighting in voting power calculation
- base reward distribution on native token stake share instead of vote power share (therefore excluding AVS stake from reward calculations)
- disallow signing from reserved zenbtc keys