### PR TITLE
fix: signature request verification

### DIFF
--- a/x/treasury/keeper/msg_server_new_sign_transaction_request.go
+++ b/x/treasury/keeper/msg_server_new_sign_transaction_request.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	errorsmod "cosmossdk.io/errors"
 	pol "github.com/Zenrock-Foundation/zrchain/v6/policy"
 	policykeeper "github.com/Zenrock-Foundation/zrchain/v6/x/policy/keeper"
 	policytypes "github.com/Zenrock-Foundation/zrchain/v6/x/policy/types"
@@ -11,14 +12,20 @@ import (
 	"github.com/Zenrock-Foundation/zrchain/v6/x/treasury/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 func (k msgServer) NewSignTransactionRequest(goCtx context.Context, msg *types.MsgNewSignTransactionRequest) (*types.MsgNewSignTransactionRequestResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	if len(msg.KeyIds) == 0 {
-		return nil, fmt.Errorf("no keys specified")
+		return nil, errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "key ids cannot be empty")
 	}
+
+	if len(msg.UnsignedTransaction) == 0 {
+		return nil, errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "unsigned transaction cannot be empty")
+	}
+
 	var keys []types.Key
 	for _, keyId := range msg.KeyIds {
 		key, err := k.KeyStore.Get(ctx, keyId)

--- a/x/treasury/keeper/msg_server_new_sign_transaction_request_test.go
+++ b/x/treasury/keeper/msg_server_new_sign_transaction_request_test.go
@@ -205,6 +205,26 @@ func Test_msgServer_NewSignTransactionRequest(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "FAIL: empty key ids",
+			args: args{
+				keyring:   &defaultKr,
+				workspace: &defaultWs,
+				key:       &defaultKey,
+				msg:       types.NewMsgNewSignTransactionRequest("testOwner", []uint64{}, types.WalletType_WALLET_TYPE_EVM, unsignedTx1, metadataAny, 1000),
+			},
+			wantErr: true,
+		},
+		{
+			name: "FAIL: empty unsigned transaction",
+			args: args{
+				keyring:   &defaultKr,
+				workspace: &defaultWs,
+				key:       &defaultKey,
+				msg:       types.NewMsgNewSignTransactionRequest("testOwner", []uint64{1}, types.WalletType_WALLET_TYPE_EVM, []byte{}, metadataAny, 1000),
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/x/treasury/keeper/msg_server_new_signature_request.go
+++ b/x/treasury/keeper/msg_server_new_signature_request.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	errorsmod "cosmossdk.io/errors"
 	"golang.org/x/exp/slices"
 
 	pol "github.com/Zenrock-Foundation/zrchain/v6/policy"
@@ -15,10 +16,19 @@ import (
 	"github.com/Zenrock-Foundation/zrchain/v6/x/treasury/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 func (k msgServer) NewSignatureRequest(goCtx context.Context, msg *types.MsgNewSignatureRequest) (*types.MsgNewSignatureRequestResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	if len(msg.KeyIds) == 0 {
+		return nil, errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "key ids cannot be empty")
+	}
+
+	if msg.DataForSigning == "" {
+		return nil, errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "data for signing cannot be empty")
+	}
 
 	key, err := k.KeyStore.Get(ctx, msg.KeyIds[0])
 	if err != nil {

--- a/x/treasury/keeper/msg_server_new_signature_request_test.go
+++ b/x/treasury/keeper/msg_server_new_signature_request_test.go
@@ -309,6 +309,26 @@ func Test_msgServer_NewSignatureRequest(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "FAIL: empty data for signing",
+			args: args{
+				keyring:   &defaultKr,
+				workspace: &defaultWs,
+				key:       &defaultKey,
+				msg:       types.NewMsgNewSignatureRequest("testOwner", []uint64{1}, "", 1000, 0),
+			},
+			wantErr: true,
+		},
+		{
+			name: "FAIL: empty key ids",
+			args: args{
+				keyring:   &defaultKr,
+				workspace: &defaultWs,
+				key:       &defaultKey,
+				msg:       types.NewMsgNewSignatureRequest("testOwner", []uint64{}, "778f572f", 1000, 0),
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This PR prevents the chain to panic if the `keyIds` array in the signature request is empty.