### PR TITLE
fix(log): remove missing nonce account for asset

### DIFF
--- a/x/validation/keeper/abci_dct.go
+++ b/x/validation/keeper/abci_dct.go
@@ -63,7 +63,6 @@ func (k *Keeper) processDCTMintsSolana(ctx sdk.Context, oracleData OracleData) {
 
 		nonceAccount := oracleData.SolanaMintNonces[solParams.NonceAccountKey]
 		if nonceAccount == nil {
-			k.Logger(ctx).Error("missing nonce account for asset", "asset", asset.String(), "nonce_account_key", solParams.NonceAccountKey)
 			continue
 		}
 


### PR DESCRIPTION
## Summary

Removes an erroneous error log that was being triggered when a nonce account was missing for a DCT asset during Solana mint processing.

## Changes

- Removed the error log "missing nonce account for asset" from processDCTMintsSolana in x/validation/keeper/abci_dct.go

## Rationale

This log was incorrectly treating a missing nonce account as an error condition. However, it is a normal scenario where we simply skip processing for that asset and continue. The code already handles this gracefully by continuing to the next asset, so logging it as an error was misleading and creating noise in the logs.

## Impact

- Eliminates erroneous error logs for ASSET_ZENZEC (and other DCT assets) when nonce accounts are temporarily unavailable
- No functional changes - the code still skips processing when nonce accounts are missing